### PR TITLE
Feat #30 카카오 토큰 발급 추가

### DIFF
--- a/src/main/java/leets/bookmark/domain/user/domain/entity/User.java
+++ b/src/main/java/leets/bookmark/domain/user/domain/entity/User.java
@@ -36,6 +36,10 @@ public class User extends BaseTimeEntity {
 
     private String refreshToken;
 
+    private String kakaoAccessToken;
+
+    private String kakaoRefreshToken;
+
     public void updateTokens(String accessToken, String refreshToken) {
         this.accessToken = accessToken;
         this.refreshToken = refreshToken;
@@ -43,5 +47,10 @@ public class User extends BaseTimeEntity {
 
     public void updateNickname(String nickname) {
         this.nickname = nickname;
+    }
+
+    public void updateKakaoTokens(String kakaoAccessToken, String kakaoRefreshToken) {
+        this.kakaoAccessToken = kakaoAccessToken;
+        this.kakaoRefreshToken = kakaoRefreshToken;
     }
 }

--- a/src/main/java/leets/bookmark/domain/user/domain/entity/User.java
+++ b/src/main/java/leets/bookmark/domain/user/domain/entity/User.java
@@ -32,17 +32,17 @@ public class User extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private Role role;
 
-    private String accessToken;
+    private String jwtAccessToken;
 
-    private String refreshToken;
+    private String jwtRefreshToken;
 
     private String kakaoAccessToken;
 
     private String kakaoRefreshToken;
 
-    public void updateTokens(String accessToken, String refreshToken) {
-        this.accessToken = accessToken;
-        this.refreshToken = refreshToken;
+    public void updateTokens(String jwtAccessToken, String jwtRefreshToken) {
+        this.jwtAccessToken = jwtAccessToken;
+        this.jwtRefreshToken = jwtRefreshToken;
     }
 
     public void updateNickname(String nickname) {

--- a/src/main/java/leets/bookmark/global/auth/jwt/application/exception/AuthJwtErrorCode.java
+++ b/src/main/java/leets/bookmark/global/auth/jwt/application/exception/AuthJwtErrorCode.java
@@ -1,4 +1,4 @@
-package leets.bookmark.global.auth.jwt.exception;
+package leets.bookmark.global.auth.jwt.application.exception;
 
 import leets.bookmark.global.common.exception.ErrorCode;
 import lombok.Getter;

--- a/src/main/java/leets/bookmark/global/auth/jwt/application/exception/UnauthorizedException.java
+++ b/src/main/java/leets/bookmark/global/auth/jwt/application/exception/UnauthorizedException.java
@@ -1,4 +1,4 @@
-package leets.bookmark.global.auth.jwt.exception;
+package leets.bookmark.global.auth.jwt.application.exception;
 
 import leets.bookmark.global.common.exception.BusinessException;
 

--- a/src/main/java/leets/bookmark/global/auth/jwt/service/CustomUserDetailsService.java
+++ b/src/main/java/leets/bookmark/global/auth/jwt/service/CustomUserDetailsService.java
@@ -2,7 +2,7 @@ package leets.bookmark.global.auth.jwt.service;
 
 import leets.bookmark.domain.user.domain.entity.User;
 import leets.bookmark.domain.user.domain.repository.UserRepository;
-import leets.bookmark.global.auth.jwt.exception.UnauthorizedException;
+import leets.bookmark.global.auth.jwt.application.exception.UnauthorizedException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;

--- a/src/main/java/leets/bookmark/global/auth/oauth2/application/exception/KakaoUserNotFoundException.java
+++ b/src/main/java/leets/bookmark/global/auth/oauth2/application/exception/KakaoUserNotFoundException.java
@@ -1,4 +1,4 @@
-package leets.bookmark.global.auth.oauth2.exception;
+package leets.bookmark.global.auth.oauth2.application.exception;
 
 import leets.bookmark.global.common.exception.BusinessException;
 

--- a/src/main/java/leets/bookmark/global/auth/oauth2/application/exception/OAuth2ErrorCode.java
+++ b/src/main/java/leets/bookmark/global/auth/oauth2/application/exception/OAuth2ErrorCode.java
@@ -1,4 +1,4 @@
-package leets.bookmark.global.auth.oauth2.exception;
+package leets.bookmark.global.auth.oauth2.application.exception;
 
 import leets.bookmark.global.common.exception.ErrorCode;
 import lombok.Getter;

--- a/src/main/java/leets/bookmark/global/auth/oauth2/application/exception/OAuth2UserInfoException.java
+++ b/src/main/java/leets/bookmark/global/auth/oauth2/application/exception/OAuth2UserInfoException.java
@@ -1,4 +1,4 @@
-package leets.bookmark.global.auth.oauth2.exception;
+package leets.bookmark.global.auth.oauth2.application.exception;
 
 import leets.bookmark.global.common.exception.BusinessException;
 

--- a/src/main/java/leets/bookmark/global/auth/oauth2/application/usecase/UserOAuth2UseCase.java
+++ b/src/main/java/leets/bookmark/global/auth/oauth2/application/usecase/UserOAuth2UseCase.java
@@ -1,4 +1,4 @@
-package leets.bookmark.global.auth.oauth2.usecase;
+package leets.bookmark.global.auth.oauth2.application.usecase;
 
 import leets.bookmark.domain.user.domain.entity.User;
 import leets.bookmark.global.auth.oauth2.userinfo.KakaoOAuth2UserInfo;

--- a/src/main/java/leets/bookmark/global/auth/oauth2/application/usecase/UserOAuth2UseCaseImpl.java
+++ b/src/main/java/leets/bookmark/global/auth/oauth2/application/usecase/UserOAuth2UseCaseImpl.java
@@ -1,4 +1,4 @@
-package leets.bookmark.global.auth.oauth2.usecase;
+package leets.bookmark.global.auth.oauth2.application.usecase;
 
 import leets.bookmark.domain.user.domain.entity.User;
 import leets.bookmark.domain.user.domain.service.UserSaveService;

--- a/src/main/java/leets/bookmark/global/auth/oauth2/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/leets/bookmark/global/auth/oauth2/handler/OAuth2SuccessHandler.java
@@ -10,7 +10,11 @@ import leets.bookmark.global.auth.jwt.service.JwtProvider;
 import leets.bookmark.global.auth.oauth2.application.exception.KakaoUserNotFoundException;
 import leets.bookmark.global.auth.oauth2.userinfo.KakaoOAuth2UserInfo;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
@@ -18,6 +22,7 @@ import org.springframework.stereotype.Component;
 import java.io.IOException;
 import java.util.Map;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
@@ -25,6 +30,7 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
     private final UserRepository userRepository;
     private final ObjectMapper objectMapper;
     private final JwtProvider jwtProvider;
+    private final OAuth2AuthorizedClientService authorizedClientService;
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException {
@@ -35,9 +41,23 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
         User user = userRepository.findByKakaoId(kakaoId)
                 .orElseThrow(KakaoUserNotFoundException::new);
 
-        JwtTokenDto token = jwtProvider.createToken(user);
+        // Kakao 제공 토큰 추출 및 저장
+        OAuth2AuthenticationToken authToken = (OAuth2AuthenticationToken) authentication;
+        OAuth2AuthorizedClient client = authorizedClientService.loadAuthorizedClient(
+                authToken.getAuthorizedClientRegistrationId(),
+                authToken.getName()
+        );
 
+        String kakaoAccessToken = client.getAccessToken().getTokenValue();
+        String kakaoRefreshToken = client.getRefreshToken() != null ?
+                client.getRefreshToken().getTokenValue() : null;
+
+        user.updateKakaoTokens(kakaoAccessToken, kakaoRefreshToken);
+
+        // JWT 토큰 발급 및 저장
+        JwtTokenDto token = jwtProvider.createToken(user);
         user.updateTokens(token.accessToken(), token.refreshToken());
+
         userRepository.save(user);
 
         response.setContentType("application/json;charset=UTF-8");

--- a/src/main/java/leets/bookmark/global/auth/oauth2/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/leets/bookmark/global/auth/oauth2/handler/OAuth2SuccessHandler.java
@@ -7,7 +7,7 @@ import leets.bookmark.domain.user.domain.entity.User;
 import leets.bookmark.domain.user.domain.repository.UserRepository;
 import leets.bookmark.global.auth.jwt.application.dto.JwtTokenDto;
 import leets.bookmark.global.auth.jwt.service.JwtProvider;
-import leets.bookmark.global.auth.oauth2.exception.KakaoUserNotFoundException;
+import leets.bookmark.global.auth.oauth2.application.exception.KakaoUserNotFoundException;
 import leets.bookmark.global.auth.oauth2.userinfo.KakaoOAuth2UserInfo;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;

--- a/src/main/java/leets/bookmark/global/auth/oauth2/service/CustomOAuth2UserService.java
+++ b/src/main/java/leets/bookmark/global/auth/oauth2/service/CustomOAuth2UserService.java
@@ -1,7 +1,7 @@
 package leets.bookmark.global.auth.oauth2.service;
 
 import leets.bookmark.domain.user.domain.entity.User;
-import leets.bookmark.global.auth.oauth2.usecase.UserOAuth2UseCase;
+import leets.bookmark.global.auth.oauth2.application.usecase.UserOAuth2UseCase;
 import leets.bookmark.global.auth.oauth2.userinfo.KakaoOAuth2UserInfo;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/leets/bookmark/global/auth/oauth2/userinfo/KakaoOAuth2UserInfo.java
+++ b/src/main/java/leets/bookmark/global/auth/oauth2/userinfo/KakaoOAuth2UserInfo.java
@@ -1,6 +1,6 @@
 package leets.bookmark.global.auth.oauth2.userinfo;
 
-import leets.bookmark.global.auth.oauth2.exception.OAuth2UserInfoException;
+import leets.bookmark.global.auth.oauth2.application.exception.OAuth2UserInfoException;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -27,9 +27,6 @@ spring:
             token-uri: ${KAKAO_TOKEN_URI}
             user-info-uri: ${KAKAO_USER_INFO_URI}
             user-name-attribute: id
-  jpa:
-    hibernate:
-      ddl-auto: update
 
 springdoc:
   swagger-ui:


### PR DESCRIPTION
## ✨ 관련 이슈

- Resolved: #30 

## 🔎 작업 내용

- 카카오에서 제공하는 토큰 DB에 저장
`OAuth2SuccessHandler`에서 진행됩니다.
발급 받은 카카오 토큰은 `users`에 저장됩니다. 필드명은 `kakaoAccessToken`, `kakaoRefreshToken`입니다.
기존 필드명이었던 `accessToken`, `refreshToken`은 모호함을 줄이고자 `jwtAccessToken`, `jwtRefreshToken`으로 변경하였습니다.

<br>


## 📌 참고 사항


- 기타 안내 사항 <!--(선택 사항)-->
  - `global.auth` 에서 일부 디렉토리 구조를 수정했습니다.
  - User 엔티티에서 필드명 변경에 따라 아래와 같이 `ddl-auto` 부분을 `create`로 하여 실행을 시켜주거나, users 테이블을 직접 drop한 후 개발을 진행해 나가셔야 테이블이 로컬에서 정상적으로 적용됩니다.
```
  jpa:
    hibernate:
      ddl-auto: create ⬅️
```
해당 사항을 진행하지 않을 경우 로컬 DB에서 `access_token`, `refresh_token` 필드는 유지된 채로 `jwt_access_token`, `jwt_refresh_token` 필드가 새로 생기게 됩니다.


<br>

## 📷 이미지 첨부
- 변경된 users 테이블입니다.
<br>
<img width="248" height="340" alt="스크린샷 2025-07-19 오후 10 04 24" src="https://github.com/user-attachments/assets/97acf559-042b-4a02-b6c2-07d34ffcd174" />

<br/>

---

## ✅ Check List
- [x] 라벨 지정
- [x] 리뷰어 지정
- [x] 담당자 지정
- [x] 테스트 완료
- [x] 이슈 제목 컨벤션 준수
- [x] PR 제목 및 설명 작성
- [x] 커밋 메시지 컨벤션 준수
