### PR TITLE
Feat #42 JWT 토큰 재발급 로직 구현

### DIFF
--- a/src/main/java/leets/bookmark/domain/user/domain/entity/User.java
+++ b/src/main/java/leets/bookmark/domain/user/domain/entity/User.java
@@ -40,7 +40,7 @@ public class User extends BaseTimeEntity {
 
     private String kakaoRefreshToken;
 
-    public void updateTokens(String jwtAccessToken, String jwtRefreshToken) {
+    public void updateJwtTokens(String jwtAccessToken, String jwtRefreshToken) {
         this.jwtAccessToken = jwtAccessToken;
         this.jwtRefreshToken = jwtRefreshToken;
     }

--- a/src/main/java/leets/bookmark/domain/user/domain/entity/User.java
+++ b/src/main/java/leets/bookmark/domain/user/domain/entity/User.java
@@ -45,6 +45,10 @@ public class User extends BaseTimeEntity {
         this.jwtRefreshToken = jwtRefreshToken;
     }
 
+    public void updateJwtAccessToken(String jwtAccessToken) {
+        this.jwtAccessToken = jwtAccessToken;
+    }
+
     public void updateNickname(String nickname) {
         this.nickname = nickname;
     }

--- a/src/main/java/leets/bookmark/domain/user/domain/service/UserSaveService.java
+++ b/src/main/java/leets/bookmark/domain/user/domain/service/UserSaveService.java
@@ -18,4 +18,8 @@ public class UserSaveService {
         return userRepository.findByKakaoId(userInfo.getProviderId())
                 .orElseGet(() -> userRepository.save(userMapper.toUser(userInfo)));
     }
+
+    public User save(User user) {
+        return userRepository.save(user);
+    }
 }

--- a/src/main/java/leets/bookmark/global/auth/jwt/application/dto/JwtTokenReissueRequest.java
+++ b/src/main/java/leets/bookmark/global/auth/jwt/application/dto/JwtTokenReissueRequest.java
@@ -1,0 +1,8 @@
+package leets.bookmark.global.auth.jwt.application.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record JwtTokenReissueRequest(
+        @NotBlank String refreshToken
+) {
+}

--- a/src/main/java/leets/bookmark/global/auth/jwt/application/exception/AuthJwtErrorCode.java
+++ b/src/main/java/leets/bookmark/global/auth/jwt/application/exception/AuthJwtErrorCode.java
@@ -10,7 +10,8 @@ import static org.springframework.http.HttpStatus.*;
 @RequiredArgsConstructor
 public enum AuthJwtErrorCode implements ErrorCode {
 
-    UNAUTHORIZED_EXCEPTION(UNAUTHORIZED.value(), "인증되지 않은 사용자입니다.");
+    UNAUTHORIZED_EXCEPTION(UNAUTHORIZED.value(), "인증되지 않은 사용자입니다."),
+    JWT_TOKEN_INVALID_EXCEPTION(401, "유효하지 않은 토큰입니다.");
 
     private final int errorCode;
     private final String message;

--- a/src/main/java/leets/bookmark/global/auth/jwt/application/exception/JwtTokenInvalidException.java
+++ b/src/main/java/leets/bookmark/global/auth/jwt/application/exception/JwtTokenInvalidException.java
@@ -1,0 +1,9 @@
+package leets.bookmark.global.auth.jwt.application.exception;
+
+import leets.bookmark.global.common.exception.BusinessException;
+
+public class JwtTokenInvalidException extends BusinessException {
+    public JwtTokenInvalidException() {
+        super(AuthJwtErrorCode.JWT_TOKEN_INVALID_EXCEPTION);
+    }
+}

--- a/src/main/java/leets/bookmark/global/auth/jwt/application/mapper/JwtMapper.java
+++ b/src/main/java/leets/bookmark/global/auth/jwt/application/mapper/JwtMapper.java
@@ -1,0 +1,23 @@
+package leets.bookmark.global.auth.jwt.application.mapper;
+
+import leets.bookmark.domain.user.domain.entity.User;
+import leets.bookmark.global.auth.jwt.application.dto.JwtTokenDto;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtMapper {
+
+    public JwtTokenDto toJwtTokenDto(User user) {
+        return JwtTokenDto.builder()
+                .accessToken(user.getJwtAccessToken())
+                .refreshToken(user.getJwtRefreshToken())
+                .build();
+    }
+
+    public JwtTokenDto toJwtTokenDto(String accessToken, String refreshToken) {
+        return JwtTokenDto.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+}

--- a/src/main/java/leets/bookmark/global/auth/jwt/service/JwtProvider.java
+++ b/src/main/java/leets/bookmark/global/auth/jwt/service/JwtProvider.java
@@ -88,4 +88,19 @@ public class JwtProvider {
                 .getBody()
                 .get(CLAIM_ID, Long.class);
     }
+
+    public long extractTokenRemainingTime(String token) {
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody()
+                    .getExpiration()
+                    .getTime() - System.currentTimeMillis();
+        } catch (JwtException | IllegalArgumentException e) {
+            log.warn("Cannot get remaining time: {}", e.getMessage());
+            return -1;
+        }
+    }
 }

--- a/src/main/java/leets/bookmark/global/auth/jwt/service/JwtProvider.java
+++ b/src/main/java/leets/bookmark/global/auth/jwt/service/JwtProvider.java
@@ -34,10 +34,18 @@ public class JwtProvider {
 
     public JwtTokenDto createToken(Object payload) {
         User user = (User) payload;
+
+        String accessToken = createAccessToken(user);
+        String refreshToken = createRefreshToken(user);
+
+        return new JwtTokenDto(accessToken, refreshToken);
+    }
+
+    public String createAccessToken(Object payload) {
+        User user = (User) payload;
         long now = new Date().getTime();
 
-        // Access Token 생성
-        String accessToken = Jwts.builder()
+        return Jwts.builder()
                 .claim(CLAIM_ID, user.getId())
                 .claim(CLAIM_EMAIL, user.getEmail())
                 .claim(CLAIM_ROLE, user.getRole())
@@ -45,16 +53,18 @@ public class JwtProvider {
                 .setExpiration(new Date(now + accessTokenExpirationMs))
                 .signWith(SignatureAlgorithm.HS256, key)
                 .compact();
+    }
 
-        // Refresh Token 생성
-        String refreshToken = Jwts.builder()
+    public String createRefreshToken(Object payload) {
+        User user = (User) payload;
+        long now = new Date().getTime();
+
+        return Jwts.builder()
                 .claim(CLAIM_ID, user.getId())
                 .setSubject(SUBJECT_REFRESH_TOKEN)
                 .setExpiration(new Date(now + refreshTokenExpirationMs))
                 .signWith(SignatureAlgorithm.HS256, key)
                 .compact();
-
-        return new JwtTokenDto(accessToken, refreshToken);
     }
 
     public boolean validateToken(String token) {

--- a/src/main/java/leets/bookmark/global/auth/jwt/service/JwtProvider.java
+++ b/src/main/java/leets/bookmark/global/auth/jwt/service/JwtProvider.java
@@ -5,6 +5,7 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import leets.bookmark.domain.user.domain.entity.User;
 import leets.bookmark.global.auth.jwt.application.dto.JwtTokenDto;
+import leets.bookmark.global.auth.jwt.application.mapper.JwtMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -23,6 +24,8 @@ public class JwtProvider {
     public static final String SUBJECT_ACCESS_TOKEN = "accessToken";
     public static final String SUBJECT_REFRESH_TOKEN = "refreshToken";
 
+    private final JwtMapper jwtMapper;
+
     @Value("${jwt.key}")
     private String key;
 
@@ -38,7 +41,7 @@ public class JwtProvider {
         String accessToken = createAccessToken(user);
         String refreshToken = createRefreshToken(user);
 
-        return new JwtTokenDto(accessToken, refreshToken);
+        return jwtMapper.toJwtTokenDto(accessToken, refreshToken);
     }
 
     public String createAccessToken(Object payload) {

--- a/src/main/java/leets/bookmark/global/auth/jwt/service/JwtProvider.java
+++ b/src/main/java/leets/bookmark/global/auth/jwt/service/JwtProvider.java
@@ -75,7 +75,7 @@ public class JwtProvider {
                     .parseClaimsJws(token);
             return true;
         } catch (JwtException | IllegalArgumentException e) {
-            log.warn("Invalid JWT Token: {}", e.getMessage());
+            log.warn("유효하지 않은 JWT 토큰입니다: {}", e.getMessage());
         }
         return false;
     }
@@ -99,7 +99,7 @@ public class JwtProvider {
                     .getExpiration()
                     .getTime() - System.currentTimeMillis();
         } catch (JwtException | IllegalArgumentException e) {
-            log.warn("Cannot get remaining time: {}", e.getMessage());
+            log.warn("유효기간을 추출하지 못했습니다: {}", e.getMessage());
             return -1;
         }
     }

--- a/src/main/java/leets/bookmark/global/auth/jwt/service/JwtService.java
+++ b/src/main/java/leets/bookmark/global/auth/jwt/service/JwtService.java
@@ -5,6 +5,7 @@ import leets.bookmark.domain.user.domain.service.UserGetService;
 import leets.bookmark.domain.user.domain.service.UserSaveService;
 import leets.bookmark.global.auth.jwt.application.dto.JwtTokenDto;
 import leets.bookmark.global.auth.jwt.application.exception.JwtTokenInvalidException;
+import leets.bookmark.global.auth.jwt.application.mapper.JwtMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -17,6 +18,7 @@ public class JwtService {
     @Value("${jwt.refresh.reissue-threshold}")
     private Long refreshReissueThreshold;
 
+    private final JwtMapper jwtMapper;
     private final JwtProvider jwtProvider;
     private final UserGetService userGetService;
     private final UserSaveService userSaveService;
@@ -44,11 +46,7 @@ public class JwtService {
         }
 
         userSaveService.save(user);
-
-        return JwtTokenDto.builder()
-                .accessToken(reissuedAccessToken)
-                .refreshToken(user.getJwtRefreshToken())
-                .build();
+        return jwtMapper.toJwtTokenDto(user);
     }
 
     private void validateRefreshTokenOwner(String refreshToken, User user) {

--- a/src/main/java/leets/bookmark/global/auth/jwt/service/JwtService.java
+++ b/src/main/java/leets/bookmark/global/auth/jwt/service/JwtService.java
@@ -1,0 +1,35 @@
+package leets.bookmark.global.auth.jwt.service;
+
+import leets.bookmark.domain.user.domain.entity.User;
+import leets.bookmark.domain.user.domain.service.UserGetService;
+import leets.bookmark.domain.user.domain.service.UserSaveService;
+import leets.bookmark.global.auth.jwt.application.dto.JwtTokenDto;
+import leets.bookmark.global.auth.jwt.application.exception.JwtTokenInvalidException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class JwtService {
+
+    private final JwtProvider jwtProvider;
+    private final UserGetService userGetService;
+    private final UserSaveService userSaveService;
+
+    @Transactional
+    public JwtTokenDto reissueToken(String refreshToken) {
+        if (!jwtProvider.validateToken(refreshToken)) {
+            throw new JwtTokenInvalidException();
+        }
+
+        Long userId = jwtProvider.extractUserId(refreshToken);
+        User user = userGetService.findById(userId);
+
+        JwtTokenDto reissuedToken = jwtProvider.createToken(user);
+        user.updateTokens(reissuedToken.accessToken(), reissuedToken.refreshToken());
+        userSaveService.save(user);
+
+        return reissuedToken;
+    }
+}

--- a/src/main/java/leets/bookmark/global/auth/jwt/service/JwtService.java
+++ b/src/main/java/leets/bookmark/global/auth/jwt/service/JwtService.java
@@ -6,12 +6,16 @@ import leets.bookmark.domain.user.domain.service.UserSaveService;
 import leets.bookmark.global.auth.jwt.application.dto.JwtTokenDto;
 import leets.bookmark.global.auth.jwt.application.exception.JwtTokenInvalidException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class JwtService {
+
+    @Value("${jwt.refresh.reissue-threshold}")
+    private Long refreshReissueThreshold;
 
     private final JwtProvider jwtProvider;
     private final UserGetService userGetService;
@@ -28,11 +32,23 @@ public class JwtService {
 
         validateRefreshTokenOwner(refreshToken, user);
 
-        JwtTokenDto reissuedToken = jwtProvider.createToken(user);
-        user.updateTokens(reissuedToken.accessToken(), reissuedToken.refreshToken());
+        String reissuedAccessToken = jwtProvider.createAccessToken(user);
+
+        long refreshTokenRemainingTime = jwtProvider.extractTokenRemainingTime(refreshToken);
+
+        if (refreshTokenRemainingTime >= 0 && refreshTokenRemainingTime < refreshReissueThreshold) {
+            String reissuedRefreshToken = jwtProvider.createRefreshToken(user);
+            user.updateTokens(reissuedAccessToken, reissuedRefreshToken);
+        } else {
+            user.updateJwtAccessToken(reissuedAccessToken);
+        }
+
         userSaveService.save(user);
 
-        return reissuedToken;
+        return JwtTokenDto.builder()
+                .accessToken(reissuedAccessToken)
+                .refreshToken(user.getJwtRefreshToken())
+                .build();
     }
 
     private void validateRefreshTokenOwner(String refreshToken, User user) {

--- a/src/main/java/leets/bookmark/global/auth/jwt/service/JwtService.java
+++ b/src/main/java/leets/bookmark/global/auth/jwt/service/JwtService.java
@@ -35,10 +35,9 @@ public class JwtService {
         validateRefreshTokenOwner(refreshToken, user);
 
         String reissuedAccessToken = jwtProvider.createAccessToken(user);
-
         long refreshTokenRemainingTime = jwtProvider.extractTokenRemainingTime(refreshToken);
 
-        if (refreshTokenRemainingTime >= 0 && refreshTokenRemainingTime < refreshReissueThreshold) {
+        if (shouldReissueRefreshToken(refreshTokenRemainingTime)) {
             String reissuedRefreshToken = jwtProvider.createRefreshToken(user);
             user.updateJwtTokens(reissuedAccessToken, reissuedRefreshToken);
         } else {
@@ -47,6 +46,10 @@ public class JwtService {
 
         userSaveService.save(user);
         return jwtMapper.toJwtTokenDto(user);
+    }
+
+    private boolean shouldReissueRefreshToken(long refreshTokenRemainingTime) {
+        return refreshTokenRemainingTime >= 0 && refreshTokenRemainingTime < refreshReissueThreshold;
     }
 
     private void validateRefreshTokenOwner(String refreshToken, User user) {

--- a/src/main/java/leets/bookmark/global/auth/jwt/service/JwtService.java
+++ b/src/main/java/leets/bookmark/global/auth/jwt/service/JwtService.java
@@ -26,10 +26,18 @@ public class JwtService {
         Long userId = jwtProvider.extractUserId(refreshToken);
         User user = userGetService.findById(userId);
 
+        validateRefreshTokenOwner(refreshToken, user);
+
         JwtTokenDto reissuedToken = jwtProvider.createToken(user);
         user.updateTokens(reissuedToken.accessToken(), reissuedToken.refreshToken());
         userSaveService.save(user);
 
         return reissuedToken;
+    }
+
+    private void validateRefreshTokenOwner(String refreshToken, User user) {
+        if (!refreshToken.equals(user.getJwtRefreshToken())) {
+            throw new JwtTokenInvalidException();
+        }
     }
 }

--- a/src/main/java/leets/bookmark/global/auth/jwt/service/JwtService.java
+++ b/src/main/java/leets/bookmark/global/auth/jwt/service/JwtService.java
@@ -38,7 +38,7 @@ public class JwtService {
 
         if (refreshTokenRemainingTime >= 0 && refreshTokenRemainingTime < refreshReissueThreshold) {
             String reissuedRefreshToken = jwtProvider.createRefreshToken(user);
-            user.updateTokens(reissuedAccessToken, reissuedRefreshToken);
+            user.updateJwtTokens(reissuedAccessToken, reissuedRefreshToken);
         } else {
             user.updateJwtAccessToken(reissuedAccessToken);
         }

--- a/src/main/java/leets/bookmark/global/auth/oauth2/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/leets/bookmark/global/auth/oauth2/handler/OAuth2SuccessHandler.java
@@ -61,7 +61,7 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 
         // JWT 토큰 발급 및 저장
         JwtTokenDto token = jwtProvider.createToken(user);
-        user.updateTokens(token.accessToken(), token.refreshToken());
+        user.updateJwtTokens(token.accessToken(), token.refreshToken());
 
         userRepository.save(user);
 

--- a/src/main/java/leets/bookmark/global/auth/presentation/AuthController.java
+++ b/src/main/java/leets/bookmark/global/auth/presentation/AuthController.java
@@ -1,0 +1,29 @@
+package leets.bookmark.global.auth.presentation;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import leets.bookmark.global.auth.jwt.application.dto.JwtTokenDto;
+import leets.bookmark.global.auth.jwt.application.dto.JwtTokenReissueRequest;
+import leets.bookmark.global.auth.jwt.service.JwtService;
+import leets.bookmark.global.common.response.CommonResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static leets.bookmark.global.auth.presentation.AuthResponseMessage.JWT_TOKEN_REISSUE_SUCCESS;
+
+@Tag(name = "AUTH", description = "사용자 인증 API")
+@RestController
+@RequestMapping("/api/v1/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final JwtService jwtService;
+
+    @PostMapping("/reissue")
+    public CommonResponse<JwtTokenDto> reissue(@RequestBody JwtTokenReissueRequest request) {
+        JwtTokenDto response = jwtService.reissueToken(request.refreshToken());
+        return CommonResponse.createSuccess(JWT_TOKEN_REISSUE_SUCCESS.getMessage(), response);
+    }
+}

--- a/src/main/java/leets/bookmark/global/auth/presentation/AuthController.java
+++ b/src/main/java/leets/bookmark/global/auth/presentation/AuthController.java
@@ -6,6 +6,7 @@ import leets.bookmark.global.auth.jwt.application.dto.JwtTokenReissueRequest;
 import leets.bookmark.global.auth.jwt.service.JwtService;
 import leets.bookmark.global.common.response.CommonResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,7 +23,7 @@ public class AuthController {
     private final JwtService jwtService;
 
     @PostMapping("/reissue")
-    public CommonResponse<JwtTokenDto> reissue(@RequestBody JwtTokenReissueRequest request) {
+    public CommonResponse<JwtTokenDto> reissue(@Validated @RequestBody JwtTokenReissueRequest request) {
         JwtTokenDto response = jwtService.reissueToken(request.refreshToken());
         return CommonResponse.createSuccess(JWT_TOKEN_REISSUE_SUCCESS.getMessage(), response);
     }

--- a/src/main/java/leets/bookmark/global/auth/presentation/AuthResponseMessage.java
+++ b/src/main/java/leets/bookmark/global/auth/presentation/AuthResponseMessage.java
@@ -1,0 +1,13 @@
+package leets.bookmark.global.auth.presentation;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum AuthResponseMessage {
+
+    JWT_TOKEN_REISSUE_SUCCESS("토큰 재발급에 성공했습니다.");
+
+    private final String message;
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -22,6 +22,7 @@ jwt:
     expiration: ${ACCESS_EXP}
   refresh:
     expiration: ${REFRESH_EXP}
+    reissue-threshold: ${REFRESH_REISSUE_THRESHOLD}
 
 cloud:
   aws:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -18,6 +18,7 @@ jwt:
     expiration: ${ACCESS_EXP}
   refresh:
     expiration: ${REFRESH_EXP}
+    reissue-threshold: ${REFRESH_REISSUE_THRESHOLD}
 
 cloud:
   aws:


### PR DESCRIPTION
## ✨ 관련 이슈

- Resolved: #42 

## 🔎 작업 내용

- JWT 토큰 재발급 로직 구현
JWT 토큰 재발급 API 생성했습니다. 재발급된 토큰은 DB에 자동으로 갱신되어 저장됩니다.
Refresh Token은 유효 기간이 지정해둔 기간보다 적을 경우 재발급되며, 그 외에는 Access Token만 재발급되도록 하였습니다.

<br>


## 📌 참고 사항

- 기타 안내사항
  - Refresh Token 만료기간 수정했습니다.
  - Refresh Token 재발급 유효기간 추가했습니다.
  - 노션 환경변수에 수정해두었으니 확인 부탁드립니다.

<br>

## 📷 이미지 첨부
- 토큰 재발급 스웨거 테스트 사진입니다.
<br>
<img width="477" height="278" alt="토큰재발급" src="https://github.com/user-attachments/assets/ae6a6162-c5db-4682-9bf3-ee987f1ace89" />

<br/>

---

## ✅ Check List
- [x] 라벨 지정
- [x] 리뷰어 지정
- [x] 담당자 지정
- [x] 테스트 완료
- [x] 이슈 제목 컨벤션 준수
- [x] PR 제목 및 설명 작성
- [x] 커밋 메시지 컨벤션 준수
