### PR TITLE
Fix #55 토큰 재발급 오류 수정

### DIFF
--- a/src/main/java/leets/bookmark/global/config/SecurityConfig.java
+++ b/src/main/java/leets/bookmark/global/config/SecurityConfig.java
@@ -37,7 +37,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                                 .requestMatchers("/health-check").permitAll()
                                 .requestMatchers("/oauth/**", "/auth/login/**").permitAll()
-                                .requestMatchers("/api/v1/auth/login/kakao").permitAll()
+                                .requestMatchers("/api/v1/auth/login/kakao", "/api/v1/auth/reissue").permitAll()
                                 .requestMatchers("/v3/api-docs", "/v3/api-docs/**", "/swagger-ui.html", "/swagger-ui/**", "/swagger/**").permitAll()
                                 .anyRequest().authenticated()
                 )


### PR DESCRIPTION
## ✨ 관련 이슈

- Resolved: #55

## 🔎 작업 내용

- 클라이언트가 토큰 재발급을 요청할 경우 `SecurityConfig`에 permit 설정을 해두지 않아 오류가 발생했습니다.
`SecurityConfig`에서 `permitAll()`에 토큰 재발급 api 추가했습니다.

<br>


---

## ✅ Check List
- [x] 라벨 지정
- [x] 리뷰어 지정
- [x] 담당자 지정
- [x] 테스트 완료
- [x] 이슈 제목 컨벤션 준수
- [x] PR 제목 및 설명 작성
- [x] 커밋 메시지 컨벤션 준수
