### PR TITLE
Hotfix #58 토큰 만료 반환 에러코드 수정

### DIFF
--- a/src/main/java/leets/bookmark/global/auth/jwt/application/exception/AuthJwtErrorCode.java
+++ b/src/main/java/leets/bookmark/global/auth/jwt/application/exception/AuthJwtErrorCode.java
@@ -10,7 +10,7 @@ import static org.springframework.http.HttpStatus.*;
 @RequiredArgsConstructor
 public enum AuthJwtErrorCode implements ErrorCode {
 
-    UNAUTHORIZED_EXCEPTION(UNAUTHORIZED.value(), "인증되지 않은 사용자입니다."),
+    UNAUTHORIZED_EXCEPTION(401, "인증되지 않은 사용자입니다."),
     JWT_TOKEN_INVALID_EXCEPTION(401, "유효하지 않은 토큰입니다."),
     AES_ENCRYPT_EXCEPTION(500, "AES 암호화에 실패하였습니다."),
     AES_DECRYPT_EXCEPTION(500, "AES 복호화에 실패하였습니다.");

--- a/src/main/java/leets/bookmark/global/config/SecurityConfig.java
+++ b/src/main/java/leets/bookmark/global/config/SecurityConfig.java
@@ -1,8 +1,11 @@
 package leets.bookmark.global.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletResponse;
 import leets.bookmark.global.auth.jwt.filter.JwtAuthenticationFilter;
 import leets.bookmark.global.auth.jwt.service.CustomUserDetailsService;
 import leets.bookmark.global.auth.jwt.service.JwtProvider;
+import leets.bookmark.global.common.response.CommonResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -10,18 +13,25 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfigurationSource;
+
+import java.io.IOException;
 
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
 
+    public static final String CONTENT_TYPE = "application/json";
+    public static final String UTF_8 = "UTF-8";
     private final JwtProvider jwtProvider;
     private final CustomUserDetailsService userDetailsService;
     private final CorsConfigurationSource corsConfigurationSource;
+    private final ObjectMapper objectMapper;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -44,6 +54,32 @@ public class SecurityConfig {
                 .addFilterBefore(
                         new JwtAuthenticationFilter(jwtProvider, userDetailsService), UsernamePasswordAuthenticationFilter.class
                 )
+                .exceptionHandling(e -> e
+                        .authenticationEntryPoint(authenticationEntryPoint())
+                        .accessDeniedHandler(accessDeniedHandler())
+                )
                 .build();
+    }
+
+    private AuthenticationEntryPoint authenticationEntryPoint() {
+        return (request, response, authException) -> {
+            setResponse(response, 401, "유효하지 않은 인증입니다.");
+        };
+    }
+
+    private AccessDeniedHandler accessDeniedHandler() {
+        return (request, response, accessDeniedException) -> {
+            setResponse(response, 403, "접근 권한이 없습니다.");
+        };
+    }
+
+    private void setResponse(HttpServletResponse response, int errorCode, String message) throws IOException {
+        response.setStatus(errorCode);
+        response.setContentType(CONTENT_TYPE);
+        response.setCharacterEncoding(UTF_8);
+
+        CommonResponse<Object> body = CommonResponse.createSuccess(message);
+        String json = objectMapper.writeValueAsString(body);
+        response.getWriter().write(json);
     }
 }


### PR DESCRIPTION
## ✨ 관련 이슈

- Resolved: #58 

## 🔎 작업 내용

- 토큰 만료 시 반환 에러 코드 값 수정
토큰 만료 후 다른 API 호출을 할 경우 스프링 시큐리티에 의해 자동적으로 403이 반환되었음을 확인했습니다.
이에 따라 `SecurityConfig`에 `exceptionHandling()`을 추가했습니다.


<br>

## 📷 이미지 첨부
- SecurityConfig에서 `exceptionHandling()`의 `authenticationEntryPoint()`가 작동하면서 사진과 같이 반환되도록 변경했습니다.
<br>
<img width="427" height="214" alt="스크린샷 2025-07-26 오전 10 36 57" src="https://github.com/user-attachments/assets/ce079f05-eb38-46bd-b6e2-4f4cb05143ce" />

<br/>

---

## ✅ Check List
- [x] 라벨 지정
- [x] 리뷰어 지정
- [x] 담당자 지정
- [x] 테스트 완료
- [x] 이슈 제목 컨벤션 준수
- [x] PR 제목 및 설명 작성
- [x] 커밋 메시지 컨벤션 준수
