### PR TITLE
Feat #61 회원탈퇴 기능 추가

### DIFF
--- a/src/main/java/leets/bookmark/domain/searchhistory/application/usecase/SearchHistoryUseCase.java
+++ b/src/main/java/leets/bookmark/domain/searchhistory/application/usecase/SearchHistoryUseCase.java
@@ -34,7 +34,8 @@ public class SearchHistoryUseCase {
     }
 
     public void deleteSearchHistory(Long userId, Long searchHistoryId) {
-        SearchHistory history = searchHistoryGetService.findByIdAndUser(searchHistoryId, userId);
+        User user = userGetService.findById(userId);
+        SearchHistory history = searchHistoryGetService.findByIdAndUser(searchHistoryId, user.getId());
         searchHistoryDeleteService.delete(history);
     }
 

--- a/src/main/java/leets/bookmark/domain/user/application/mapper/UserMapper.java
+++ b/src/main/java/leets/bookmark/domain/user/application/mapper/UserMapper.java
@@ -4,6 +4,7 @@ import leets.bookmark.domain.user.application.dto.response.UserInfoResponse;
 import leets.bookmark.domain.user.application.dto.response.UserKakaoLoginResponse;
 import leets.bookmark.domain.user.domain.entity.User;
 import leets.bookmark.domain.user.domain.entity.enums.Role;
+import leets.bookmark.domain.user.domain.entity.enums.Status;
 import leets.bookmark.global.auth.oauth2.application.dto.response.KakaoUserInfoResponse;
 import org.springframework.stereotype.Component;
 
@@ -17,6 +18,7 @@ public class UserMapper {
                 .nickname(userInfo.kakaoAccount().profile().nickName())
                 .profileImage(userInfo.kakaoAccount().profile().profileImageUrl())
                 .role(Role.USER)
+                .status(Status.ACTIVE)
                 .build();
     }
 

--- a/src/main/java/leets/bookmark/domain/user/application/usecase/UserUseCase.java
+++ b/src/main/java/leets/bookmark/domain/user/application/usecase/UserUseCase.java
@@ -6,4 +6,6 @@ public interface UserUseCase {
     UserInfoResponse getUserInfo(Long userId);
 
     void updateNickname(Long userId, String newNickname);
+
+    void withdraw(Long userId);
 }

--- a/src/main/java/leets/bookmark/domain/user/application/usecase/UserUseCaseImpl.java
+++ b/src/main/java/leets/bookmark/domain/user/application/usecase/UserUseCaseImpl.java
@@ -9,11 +9,9 @@ import leets.bookmark.global.auth.jwt.service.AesEncryptor;
 import leets.bookmark.global.auth.oauth2.service.KakaoTokenRefreshService;
 import leets.bookmark.global.auth.oauth2.service.KakaoUnlinkService;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 public class UserUseCaseImpl implements UserUseCase {
@@ -48,8 +46,6 @@ public class UserUseCaseImpl implements UserUseCase {
         String kakaoAccessToken = aesEncryptor.decrypt(user.getKakaoAccessToken());
         kakaoUnlinkService.unlink(kakaoAccessToken);
 
-        // TODO: 사용자 삭제 or 사용자 soft delete 처리
-        user.deleteAllTokens(); // 임시
-        log.info(" [UserUseCaseImpl] 회원 탈퇴 완료");
+        user.withdraw();
     }
 }

--- a/src/main/java/leets/bookmark/domain/user/application/usecase/UserUseCaseImpl.java
+++ b/src/main/java/leets/bookmark/domain/user/application/usecase/UserUseCaseImpl.java
@@ -5,10 +5,15 @@ import leets.bookmark.domain.user.application.mapper.UserMapper;
 import leets.bookmark.domain.user.domain.entity.User;
 import leets.bookmark.domain.user.domain.service.UserGetService;
 import leets.bookmark.domain.user.domain.service.UserUpdateService;
+import leets.bookmark.global.auth.jwt.service.AesEncryptor;
+import leets.bookmark.global.auth.oauth2.service.KakaoTokenRefreshService;
+import leets.bookmark.global.auth.oauth2.service.KakaoUnlinkService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class UserUseCaseImpl implements UserUseCase {
@@ -16,6 +21,9 @@ public class UserUseCaseImpl implements UserUseCase {
     private final UserGetService userGetService;
     private final UserUpdateService userUpdateService;
     private final UserMapper userMapper;
+    private final KakaoUnlinkService kakaoUnlinkService;
+    private final AesEncryptor aesEncryptor;
+    private final KakaoTokenRefreshService kakaoTokenRefreshService;
 
     @Transactional(readOnly = true)
     @Override
@@ -29,5 +37,19 @@ public class UserUseCaseImpl implements UserUseCase {
     public void updateNickname(Long userId, String newNickname) {
         User user = userGetService.findById(userId);
         userUpdateService.updateNickname(user, newNickname);
+    }
+
+    @Transactional
+    @Override
+    public void withdraw(Long userId) {
+        User user = userGetService.findById(userId);
+        kakaoTokenRefreshService.refreshAccessToken(user);
+
+        String kakaoAccessToken = aesEncryptor.decrypt(user.getKakaoAccessToken());
+        kakaoUnlinkService.unlink(kakaoAccessToken);
+
+        // TODO: 사용자 삭제 or 사용자 soft delete 처리
+        user.deleteAllTokens(); // 임시
+        log.info(" [UserUseCaseImpl] 회원 탈퇴 완료");
     }
 }

--- a/src/main/java/leets/bookmark/domain/user/domain/entity/User.java
+++ b/src/main/java/leets/bookmark/domain/user/domain/entity/User.java
@@ -20,6 +20,7 @@ public class User extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(nullable = false)
     private Long id;
 
     private String kakaoId;
@@ -31,6 +32,7 @@ public class User extends BaseTimeEntity {
     private String profileImage;
 
     @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
     private Role role;
 
     private String jwtAccessToken;
@@ -42,6 +44,7 @@ public class User extends BaseTimeEntity {
     private String kakaoRefreshToken;
 
     @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
     private Status status;
 
     public void updateJwtTokens(String jwtAccessToken, String jwtRefreshToken) {

--- a/src/main/java/leets/bookmark/domain/user/domain/entity/User.java
+++ b/src/main/java/leets/bookmark/domain/user/domain/entity/User.java
@@ -2,6 +2,7 @@ package leets.bookmark.domain.user.domain.entity;
 
 import jakarta.persistence.*;
 import leets.bookmark.domain.user.domain.entity.enums.Role;
+import leets.bookmark.domain.user.domain.entity.enums.Status;
 import leets.bookmark.global.common.entity.BaseTimeEntity;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -40,6 +41,9 @@ public class User extends BaseTimeEntity {
 
     private String kakaoRefreshToken;
 
+    @Enumerated(EnumType.STRING)
+    private Status status;
+
     public void updateJwtTokens(String jwtAccessToken, String jwtRefreshToken) {
         this.jwtAccessToken = jwtAccessToken;
         this.jwtRefreshToken = jwtRefreshToken;
@@ -67,5 +71,11 @@ public class User extends BaseTimeEntity {
         this.jwtRefreshToken = null;
         this.kakaoAccessToken = null;
         this.kakaoRefreshToken = null;
+    }
+
+    public void withdraw() {
+        this.status = Status.DELETED;
+        this.kakaoId = null;
+        deleteAllTokens();
     }
 }

--- a/src/main/java/leets/bookmark/domain/user/domain/entity/User.java
+++ b/src/main/java/leets/bookmark/domain/user/domain/entity/User.java
@@ -61,4 +61,11 @@ public class User extends BaseTimeEntity {
     public void updateKakaoAccessToken(String kakaoAccessToken) {
         this.kakaoAccessToken = kakaoAccessToken;
     }
+
+    public void deleteAllTokens() {
+        this.jwtAccessToken = null;
+        this.jwtRefreshToken = null;
+        this.kakaoAccessToken = null;
+        this.kakaoRefreshToken = null;
+    }
 }

--- a/src/main/java/leets/bookmark/domain/user/domain/entity/enums/Status.java
+++ b/src/main/java/leets/bookmark/domain/user/domain/entity/enums/Status.java
@@ -1,0 +1,9 @@
+package leets.bookmark.domain.user.domain.entity.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum Status {
+    ACTIVE,
+    DELETED
+}

--- a/src/main/java/leets/bookmark/domain/user/domain/repository/UserRepository.java
+++ b/src/main/java/leets/bookmark/domain/user/domain/repository/UserRepository.java
@@ -1,10 +1,13 @@
 package leets.bookmark.domain.user.domain.repository;
 
 import leets.bookmark.domain.user.domain.entity.User;
+import leets.bookmark.domain.user.domain.entity.enums.Status;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByKakaoId(String kakaoId);
+
+    Optional<User> findByIdAndStatus(Long id, Status status);
 }

--- a/src/main/java/leets/bookmark/domain/user/domain/service/UserGetService.java
+++ b/src/main/java/leets/bookmark/domain/user/domain/service/UserGetService.java
@@ -2,6 +2,7 @@ package leets.bookmark.domain.user.domain.service;
 
 import leets.bookmark.domain.user.application.exception.UserNotFoundException;
 import leets.bookmark.domain.user.domain.entity.User;
+import leets.bookmark.domain.user.domain.entity.enums.Status;
 import leets.bookmark.domain.user.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -13,7 +14,7 @@ public class UserGetService {
     private final UserRepository userRepository;
 
     public User findById(Long userId) {
-        return userRepository.findById(userId)
+        return userRepository.findByIdAndStatus(userId, Status.ACTIVE)
                 .orElseThrow(UserNotFoundException::new);
     }
 }

--- a/src/main/java/leets/bookmark/domain/user/presentation/UserController.java
+++ b/src/main/java/leets/bookmark/domain/user/presentation/UserController.java
@@ -37,4 +37,11 @@ public class UserController {
         userUseCase.updateNickname(userId, request.nickname());
         return CommonResponse.createSuccess(UPDATE_USER_NICKNAME_SUCCESS.getMessage());
     }
+
+    @DeleteMapping("/withdraw")
+    @Operation(summary = "회원탈퇴 API", description = "사용자가 회원 탈퇴를 요청하는 API입니다.")
+    public CommonResponse<Void> withdrawUser(@CurrentUser Long userId) {
+        userUseCase.withdraw(userId);
+        return CommonResponse.createSuccess(WITHDRAW_USER_SUCCESS.getMessage());
+    }
 }

--- a/src/main/java/leets/bookmark/domain/user/presentation/UserResponseMessage.java
+++ b/src/main/java/leets/bookmark/domain/user/presentation/UserResponseMessage.java
@@ -8,7 +8,7 @@ import lombok.RequiredArgsConstructor;
 public enum UserResponseMessage {
 
     GET_USER_INFO_SUCCESS("정보 조회에 성공했습니다."),
-    UPDATE_USER_NICKNAME_SUCCESS("닉네임 변경에 성공했습니다"),
+    UPDATE_USER_NICKNAME_SUCCESS("닉네임 변경에 성공했습니다."),
     WITHDRAW_USER_SUCCESS("정상적으로 탈퇴되었습니다.");
 
     private final String message;

--- a/src/main/java/leets/bookmark/domain/user/presentation/UserResponseMessage.java
+++ b/src/main/java/leets/bookmark/domain/user/presentation/UserResponseMessage.java
@@ -1,14 +1,15 @@
 package leets.bookmark.domain.user.presentation;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 @Getter
-@AllArgsConstructor
+@RequiredArgsConstructor
 public enum UserResponseMessage {
 
     GET_USER_INFO_SUCCESS("정보 조회에 성공했습니다."),
-    UPDATE_USER_NICKNAME_SUCCESS("닉네임 변경에 성공했습니다");
+    UPDATE_USER_NICKNAME_SUCCESS("닉네임 변경에 성공했습니다"),
+    WITHDRAW_USER_SUCCESS("정상적으로 탈퇴되었습니다.");
 
     private final String message;
 }

--- a/src/main/java/leets/bookmark/global/auth/jwt/service/CustomUserDetailsService.java
+++ b/src/main/java/leets/bookmark/global/auth/jwt/service/CustomUserDetailsService.java
@@ -1,6 +1,7 @@
 package leets.bookmark.global.auth.jwt.service;
 
 import leets.bookmark.domain.user.domain.entity.User;
+import leets.bookmark.domain.user.domain.entity.enums.Status;
 import leets.bookmark.domain.user.domain.repository.UserRepository;
 import leets.bookmark.global.auth.jwt.application.exception.UnauthorizedException;
 import lombok.RequiredArgsConstructor;
@@ -17,7 +18,7 @@ public class CustomUserDetailsService implements UserDetailsService {
 
     @Override
     public UserDetails loadUserByUsername(String userId) throws UsernameNotFoundException {
-        User user = userRepository.findById(Long.parseLong(userId))
+        User user = userRepository.findByIdAndStatus(Long.valueOf(userId), Status.ACTIVE)
                 .orElseThrow(UnauthorizedException::new);
 
         return new CustomUserDetails(user);

--- a/src/main/java/leets/bookmark/global/auth/oauth2/service/KakaoUnlinkService.java
+++ b/src/main/java/leets/bookmark/global/auth/oauth2/service/KakaoUnlinkService.java
@@ -1,0 +1,34 @@
+package leets.bookmark.global.auth.oauth2.service;
+
+import leets.bookmark.global.auth.oauth2.application.exception.KakaoAccessTokenInvalidException;
+import leets.bookmark.global.auth.oauth2.application.exception.KakaoServerException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
+
+@Service
+@RequiredArgsConstructor
+public class KakaoUnlinkService {
+
+    public static final String KAKAO_UNLINK_URI = "https://kapi.kakao.com/v1/user/unlink";
+    public static final String BEARER = "Bearer ";
+    public static final String APPLICATION_X_WWW_FORM_URLENCODED_CHARSET_UTF_8 = "application/x-www-form-urlencoded;charset=utf-8";
+
+    public void unlink(String kakaoAccessToken) {
+        WebClient.create(KAKAO_UNLINK_URI).post()
+                .uri(uriBuilder -> uriBuilder
+                        .build(true))
+                .header(AUTHORIZATION, BEARER + kakaoAccessToken)
+                .header(CONTENT_TYPE, APPLICATION_X_WWW_FORM_URLENCODED_CHARSET_UTF_8)
+                .retrieve()
+                .onStatus(HttpStatusCode::is4xxClientError, clientResponse -> Mono.error(KakaoAccessTokenInvalidException::new))
+                .onStatus(HttpStatusCode::is5xxServerError, clientResponse -> Mono.error(KakaoServerException::new))
+                .bodyToMono(String.class)
+                .block();
+    }
+}


### PR DESCRIPTION
## ✨ 관련 이슈

- Resolved: #61 

## 🔎 작업 내용

- 회원탈퇴 로직 추가
  - `status` 필드를 추가하여 enum(`ACTIVE`, `DELETED`)으로 관리합니다.
  - 회원 가입 시 `ACTIVE`로 가입되며, 탈퇴 시 `status`가 `DELETED`로 변경됩니다.
  - 탈퇴 요청 시 JWT 토큰, Kakao로부터 발급된 토큰, Kakao 고유 ID가 DB에서 삭제됩니다.

<br>


## 📌 참고 사항

- 기타 안내 사항 <!--(선택 사항)-->
  - `status` 필드가 추가됨에 따라 UserGetService에서 `findById()` 메소드를 일부 수정했습니다.
  - 현재로선 탈퇴 후 재가입이 가능합니다.

- 주의해야 할 점 <!--(선택 사항)-->
  - `status` 필드가 추가됨에 따라 현재 로컬 및 서버에 가입되어 있는 회원의 `status`에 모두 수동으로 `ACTIVE`를 추가해야 합니다.

<!-- 내용이 없을 경우 해당 항목은 삭제해 주세요 -->

<br>

## 📷 이미지 첨부
- 회원탈퇴 테스트입니다.
<br>
<img width="480" height="275" alt="탈퇴 완료" src="https://github.com/user-attachments/assets/0f88d6b3-249d-4270-a00f-aa00d51dd5f8" />
<img width="756" height="170" alt="탈퇴 후 DB" src="https://github.com/user-attachments/assets/83c63cfa-725c-4649-8191-3686986fffa9" />

<br>

- 현재 재가입이 가능한 상태입니다.
<br>
<img width="427" height="294" alt="재가입 가능" src="https://github.com/user-attachments/assets/02547835-ddd8-476f-a444-68dfe2dc3af8" />


<br/>

---

## ✅ Check List
- [x] 라벨 지정
- [x] 리뷰어 지정
- [x] 담당자 지정
- [x] 테스트 완료
- [x] 이슈 제목 컨벤션 준수
- [x] PR 제목 및 설명 작성
- [x] 커밋 메시지 컨벤션 준수
