### PR TITLE
Feat #71 카테고리 태그 반환 시 플랫폼 추가

### DIFF
--- a/src/main/java/leets/bookmark/domain/bookmark/application/mapper/BookmarkCategoryMapper.java
+++ b/src/main/java/leets/bookmark/domain/bookmark/application/mapper/BookmarkCategoryMapper.java
@@ -1,0 +1,54 @@
+package leets.bookmark.domain.bookmark.application.mapper;
+
+import leets.bookmark.domain.bookmark.domain.entity.Bookmark;
+import leets.bookmark.domain.bookmark.domain.entity.enums.Platform;
+import leets.bookmark.domain.bookmark.domain.service.BookmarkGetService;
+import leets.bookmark.domain.category.domain.entity.Category;
+import leets.bookmark.domain.file.domain.entity.File;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class BookmarkCategoryMapper {
+
+    private final BookmarkGetService bookmarkGetService;
+
+    public Map<Long, List<String>> toThumbnailMap(List<Category> categories) {
+        Map<Long, List<String>> thumbnailMap = new HashMap<>();
+
+        for (Category category : categories) {
+            List<Bookmark> bookmarks = bookmarkGetService.getRecent3BookmarksByCategory(category);
+
+            List<String> thumbnailUrls = bookmarks.stream()
+                    .map(Bookmark::getFile)
+                    .map(File::getFileUrl)
+                    .toList();
+
+            thumbnailMap.put(category.getId(), thumbnailUrls);
+        }
+
+        return thumbnailMap;
+    }
+
+    public Map<Long, List<Platform>> toPlatformMap(List<Category> categories) {
+        Map<Long, List<Platform>> platformMap = new HashMap<>();
+
+        for (Category category : categories) {
+            List<Bookmark> bookmarks = bookmarkGetService.getBookmarksByCategory(category);
+
+            List<Platform> platforms = bookmarks.stream()
+                    .map(Bookmark::getPlatform)
+                    .distinct()
+                    .toList();
+
+            platformMap.put(category.getId(), platforms);
+        }
+
+        return platformMap;
+    }
+}

--- a/src/main/java/leets/bookmark/domain/category/application/dto/response/CategoryWithTagResponse.java
+++ b/src/main/java/leets/bookmark/domain/category/application/dto/response/CategoryWithTagResponse.java
@@ -1,5 +1,6 @@
 package leets.bookmark.domain.category.application.dto.response;
 
+import leets.bookmark.domain.bookmark.domain.entity.enums.Platform;
 import leets.bookmark.domain.tag.application.dto.response.TagResponse;
 import lombok.Builder;
 
@@ -9,6 +10,7 @@ import java.util.List;
 public record CategoryWithTagResponse(
         Long categoryId,
         String categoryName,
-        List<TagResponse> tags
+        List<TagResponse> tags,
+        List<Platform> platforms
 ) {
 }

--- a/src/main/java/leets/bookmark/domain/category/application/mapper/CategoryMapper.java
+++ b/src/main/java/leets/bookmark/domain/category/application/mapper/CategoryMapper.java
@@ -1,5 +1,6 @@
 package leets.bookmark.domain.category.application.mapper;
 
+import leets.bookmark.domain.bookmark.domain.entity.enums.Platform;
 import leets.bookmark.domain.category.application.dto.request.CategoryCreateRequest;
 import leets.bookmark.domain.category.application.dto.response.CategoryResponse;
 import leets.bookmark.domain.category.application.dto.response.CategoryWithTagResponse;
@@ -47,24 +48,26 @@ public class CategoryMapper {
                 .toList();
     }
 
-    public CategoryWithTagResponse toCategoryWithTagResponse(Category category, List<Tag> tags) {
+    public CategoryWithTagResponse toCategoryWithTagResponse(Category category, List<Tag> tags, List<Platform> platforms) {
         List<TagResponse> tagResponse = tagMapper.toTagResponseList(tags);
 
         return CategoryWithTagResponse.builder()
                 .categoryId(category.getId())
                 .categoryName(category.getCategoryName())
                 .tags(tagResponse)
+                .platforms(platforms)
                 .build();
     }
 
-    public List<CategoryWithTagResponse> toCategoryWithTagResponseList(List<Category> categories, List<Tag> tags) {
+    public List<CategoryWithTagResponse> toCategoryWithTagResponseList(List<Category> categories, List<Tag> tags, Map<Long, List<Platform>> platformMap) {
         Map<Long, List<Tag>> tagMap = tags.stream()
                 .collect(Collectors.groupingBy(tag -> tag.getCategory().getId()));
 
         return categories.stream()
                 .map(category -> {
                     List<Tag> tagList = tagMap.getOrDefault(category.getId(), List.of());
-                    return toCategoryWithTagResponse(category, tagList);
+                    List<Platform> platformList = platformMap.getOrDefault(category.getId(), List.of());
+                    return toCategoryWithTagResponse(category, tagList, platformList);
                 })
                 .toList();
     }

--- a/src/main/java/leets/bookmark/domain/category/application/usecase/CategoryUseCaseImpl.java
+++ b/src/main/java/leets/bookmark/domain/category/application/usecase/CategoryUseCaseImpl.java
@@ -1,6 +1,6 @@
 package leets.bookmark.domain.category.application.usecase;
 
-import leets.bookmark.domain.bookmark.domain.entity.Bookmark;
+import leets.bookmark.domain.bookmark.application.mapper.BookmarkCategoryMapper;
 import leets.bookmark.domain.bookmark.domain.entity.enums.Platform;
 import leets.bookmark.domain.bookmark.domain.service.BookmarkGetService;
 import leets.bookmark.domain.category.application.dto.request.CategoryCreateRequest;
@@ -17,7 +17,6 @@ import leets.bookmark.domain.category.domain.service.CategoryGetService;
 import leets.bookmark.domain.category.domain.service.CategorySaveService;
 import leets.bookmark.domain.category.domain.entity.Category;
 import leets.bookmark.domain.category.domain.service.CategoryUpdateService;
-import leets.bookmark.domain.file.domain.entity.File;
 import leets.bookmark.domain.tag.domain.entity.Tag;
 import leets.bookmark.domain.tag.domain.service.TagDeleteService;
 import leets.bookmark.domain.tag.domain.service.TagGetService;
@@ -27,7 +26,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -44,9 +42,10 @@ public class CategoryUseCaseImpl implements CategoryUseCase {
     private final CategoryUpdateService categoryUpdateService;
     private final TagGetService tagGetService;
     private final TagDeleteService tagDeleteService;
+    private final BookmarkGetService bookmarkGetService;
 
     private final CategoryMapper categoryMapper;
-    private final BookmarkGetService bookmarkGetService;
+    private final BookmarkCategoryMapper bookmarkCategoryMapper;
 
     @Transactional
     @Override
@@ -66,19 +65,7 @@ public class CategoryUseCaseImpl implements CategoryUseCase {
         User user = userGetService.findById(userId);
 
         List<Category> categories = categoryGetService.getAllByUser(user);
-
-        Map<Long, List<String>> thumbnailMap = new HashMap<>();
-
-        for (Category category : categories) {
-            List<Bookmark> bookmarks = bookmarkGetService.getRecent3BookmarksByCategory(category);
-
-            List<String> thumbnailUrls = bookmarks.stream()
-                    .map(Bookmark::getFile)
-                    .map(File::getFileUrl)
-                    .toList();
-
-            thumbnailMap.put(category.getId(), thumbnailUrls);
-        }
+        Map<Long, List<String>> thumbnailMap = bookmarkCategoryMapper.toThumbnailMap(categories);
 
         return categoryMapper.toCategoryResponseList(categories, thumbnailMap);
     }
@@ -90,19 +77,7 @@ public class CategoryUseCaseImpl implements CategoryUseCase {
 
         List<Category> categories = categoryGetService.getAllByUser(user);
         List<Tag> tags = tagGetService.findAllByUser(user);
-
-        Map<Long, List<Platform>> platformMap = new HashMap<>();
-
-        for (Category category : categories) {
-            List<Bookmark> bookmarks = bookmarkGetService.getBookmarksByCategory(category);
-
-            List<Platform> platforms = bookmarks.stream()
-                    .map(Bookmark::getPlatform)
-                    .distinct()
-                    .toList();
-
-            platformMap.put(category.getId(), platforms);
-        }
+        Map<Long, List<Platform>> platformMap = bookmarkCategoryMapper.toPlatformMap(categories);
 
         return categoryMapper.toCategoryWithTagResponseList(categories, tags, platformMap);
     }

--- a/src/main/java/leets/bookmark/domain/category/application/usecase/CategoryUseCaseImpl.java
+++ b/src/main/java/leets/bookmark/domain/category/application/usecase/CategoryUseCaseImpl.java
@@ -1,6 +1,7 @@
 package leets.bookmark.domain.category.application.usecase;
 
 import leets.bookmark.domain.bookmark.domain.entity.Bookmark;
+import leets.bookmark.domain.bookmark.domain.entity.enums.Platform;
 import leets.bookmark.domain.bookmark.domain.service.BookmarkGetService;
 import leets.bookmark.domain.category.application.dto.request.CategoryCreateRequest;
 import leets.bookmark.domain.category.application.dto.request.CategoryNameUpdateRequest;
@@ -90,7 +91,20 @@ public class CategoryUseCaseImpl implements CategoryUseCase {
         List<Category> categories = categoryGetService.getAllByUser(user);
         List<Tag> tags = tagGetService.findAllByUser(user);
 
-        return categoryMapper.toCategoryWithTagResponseList(categories, tags);
+        Map<Long, List<Platform>> platformMap = new HashMap<>();
+
+        for (Category category : categories) {
+            List<Bookmark> bookmarks = bookmarkGetService.getBookmarksByCategory(category);
+
+            List<Platform> platforms = bookmarks.stream()
+                    .map(Bookmark::getPlatform)
+                    .distinct()
+                    .toList();
+
+            platformMap.put(category.getId(), platforms);
+        }
+
+        return categoryMapper.toCategoryWithTagResponseList(categories, tags, platformMap);
     }
 
     @Transactional


### PR DESCRIPTION
## ✨ 관련 이슈

- Resolved: #71 

## 🔎 작업 내용

- 카테고리 및 태그 전체 조회 API 수정
  - 반환되는 항목에 플랫폼 추가했습니다.
  - 한 카테고리 내에서 중복되는 플랫폼은 한 번만 반환되도록 했습니다.
- 리팩토링 진행
  - `BookmarkCategoryMapper`를 추가해서 `CategoryUseCaseImpl`과의 기능을 나눴습니다.

<br>

<br>

## 📷 이미지 첨부
- 카테고리 및 태그 전체 조회 시 플랫폼이 반환됩니다.
  - 카테고리 ID#1에 총 4개의 북마크가 저장되어 있으며 모두 NAVER 플랫폼을 사용합니다. 중복 플랫폼이 있을 경우 한번만 반환됨을 확인했습니다.
  - 카테고리 ID#2에는 총 2개의 북마크가 저장되어 있으며 각각 NAVER, TISTORY 플랫폼을 사용합니다.
<br>
<img width="601" height="580" alt="수정된 api" src="https://github.com/user-attachments/assets/6df7d873-721f-4fab-a85b-8c193cc52e62" />
<br>
반환된 전체 내용은 아래와 같습니다.

```
{
  "code": 200,
  "message": "전체 카테고리 및 하위 태그 조회에 성공했습니다.",
  "data": [
    {
      "categoryId": 1,
      "categoryName": "백엔드",
      "tags": [
        {
          "tagId": 1,
          "categoryId": 1,
          "tagName": "스프링"
        },
        {
          "tagId": 2,
          "categoryId": 1,
          "tagName": "자바"
        }
      ],
      "platforms": [
        "NAVER"
      ]
    },
    {
      "categoryId": 2,
      "categoryName": "프론트엔드",
      "tags": [
        {
          "tagId": 3,
          "categoryId": 2,
          "tagName": "리액트"
        }
      ],
      "platforms": [
        "NAVER",
        "TISTORY"
      ]
    },
    {
      "categoryId": 3,
      "categoryName": "기타",
      "tags": [],
      "platforms": []
    }
  ]
}
```


<br/>

---

## ✅ Check List
- [x] 라벨 지정
- [x] 리뷰어 지정
- [x] 담당자 지정
- [x] 테스트 완료
- [x] 이슈 제목 컨벤션 준수
- [x] PR 제목 및 설명 작성
- [x] 커밋 메시지 컨벤션 준수
