### PR TITLE
Feat #74 플랫폼 조회 기능 추가

### DIFF
--- a/src/main/java/leets/bookmark/domain/bookmark/application/dto/response/BookmarkPlatformResponse.java
+++ b/src/main/java/leets/bookmark/domain/bookmark/application/dto/response/BookmarkPlatformResponse.java
@@ -1,0 +1,10 @@
+package leets.bookmark.domain.bookmark.application.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record BookmarkPlatformResponse(
+        String platform,
+        String faviconUrl
+) {
+}

--- a/src/main/java/leets/bookmark/domain/bookmark/application/mapper/BookmarkPlatformMapper.java
+++ b/src/main/java/leets/bookmark/domain/bookmark/application/mapper/BookmarkPlatformMapper.java
@@ -1,0 +1,41 @@
+package leets.bookmark.domain.bookmark.application.mapper;
+
+import leets.bookmark.domain.bookmark.application.dto.response.BookmarkPlatformResponse;
+import leets.bookmark.domain.bookmark.domain.entity.Bookmark;
+import leets.bookmark.domain.bookmark.domain.entity.enums.Platform;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class BookmarkPlatformMapper {
+
+    public BookmarkPlatformResponse toBookmarkPlatformResponse(Bookmark bookmark) {
+        return BookmarkPlatformResponse.builder()
+                .platform(String.valueOf(bookmark.getPlatform().getPlatformName()))
+                .faviconUrl(bookmark.getFaviconUrl())
+                .build();
+    }
+
+    public List<BookmarkPlatformResponse> toBookmarkPlatformResponseList(List<Bookmark> bookmarks) {
+        return bookmarks.stream()
+                .map(this::toBookmarkPlatformResponse)
+                .distinct()
+                .toList();
+    }
+
+    public List<Bookmark> toBookmarkPlatformList(List<Bookmark> bookmarks) {
+        Map<Platform, Bookmark> platforms = new EnumMap<>(Platform.class);
+
+        for (Bookmark bookmark : bookmarks) {
+            platforms.putIfAbsent(bookmark.getPlatform(), bookmark);
+        }
+
+        return new ArrayList<>(platforms.values());
+    }
+}

--- a/src/main/java/leets/bookmark/domain/bookmark/application/usecase/BookmarkUseCase.java
+++ b/src/main/java/leets/bookmark/domain/bookmark/application/usecase/BookmarkUseCase.java
@@ -6,11 +6,10 @@ import leets.bookmark.domain.bookmark.application.dto.response.BookmarkPreviewRe
 
 import leets.bookmark.domain.bookmark.application.dto.request.BookmarkSearchRequest;
 import leets.bookmark.domain.bookmark.application.dto.response.BookmarkResponse;
+import leets.bookmark.domain.bookmark.application.dto.response.BookmarkPlatformResponse;
 import org.springframework.data.domain.Slice;
-import leets.bookmark.domain.bookmark.domain.entity.enums.Platform;
 import leets.bookmark.domain.notification.application.usecase.NotificationUseCase;
 import org.springframework.stereotype.Service;
-import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
@@ -24,6 +23,7 @@ public interface BookmarkUseCase {
 
     void save(Long userId, BookmarkSaveRequest request);
 
-
     List<BookmarkPreviewResponse> extractPreviewFromUrl(String url);
+
+    List<BookmarkPlatformResponse> getAllPlatforms(Long userId);
 }

--- a/src/main/java/leets/bookmark/domain/bookmark/application/usecase/BookmarkUseCaseImpl.java
+++ b/src/main/java/leets/bookmark/domain/bookmark/application/usecase/BookmarkUseCaseImpl.java
@@ -9,7 +9,9 @@ import java.util.stream.Collectors;
 import leets.bookmark.domain.bookmark.application.dto.request.BookmarkSearchCondition;
 import leets.bookmark.domain.bookmark.application.dto.request.CategoryTagRequest;
 import leets.bookmark.domain.bookmark.application.dto.response.BookmarkPreviewResponse;
+import leets.bookmark.domain.bookmark.application.dto.response.BookmarkPlatformResponse;
 import leets.bookmark.domain.bookmark.application.exception.TagCategoryMismatchException;
+import leets.bookmark.domain.bookmark.application.mapper.BookmarkPlatformMapper;
 import leets.bookmark.domain.bookmark.application.mapper.BookmarkSearchConditionMapper;
 import leets.bookmark.domain.bookmark.domain.entity.BookmarkTagMapping;
 import leets.bookmark.domain.bookmark.domain.repository.BookmarkTagMappingRepository;
@@ -73,6 +75,7 @@ public class BookmarkUseCaseImpl implements BookmarkUseCase {
     private final FileGetService fileGetService;
 
     private final BookmarkTagMappingRepository bookmarkTagMappingRepository;
+    private final BookmarkPlatformMapper bookmarkPlatformMapper;
 
     @Override
     @Transactional(readOnly = true)
@@ -254,6 +257,14 @@ public class BookmarkUseCaseImpl implements BookmarkUseCase {
     @Override
     public List<BookmarkPreviewResponse> extractPreviewFromUrl(String url) {
         return bookmarkPreviewService.extractPreviewFromUrl(url);
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public List<BookmarkPlatformResponse> getAllPlatforms(Long userId) {
+        User user = userGetService.findById(userId);
+        List<Bookmark> bookmarks = bookmarkGetService.getDistinctPlatformsByUser(user);
+        return bookmarkPlatformMapper.toBookmarkPlatformResponseList(bookmarks);
     }
 
     private void validateTags(List<Tag> tags, Category category){

--- a/src/main/java/leets/bookmark/domain/bookmark/application/usecase/BookmarkUseCaseImpl.java
+++ b/src/main/java/leets/bookmark/domain/bookmark/application/usecase/BookmarkUseCaseImpl.java
@@ -23,7 +23,6 @@ import leets.bookmark.domain.bookmark.domain.service.BookmarkPreviewService;
 import leets.bookmark.domain.file.application.dto.response.FileResponse;
 import leets.bookmark.domain.file.application.mapper.FileMapper;
 import leets.bookmark.domain.file.application.usecase.FileUseCase;
-import leets.bookmark.domain.file.domain.service.FileGetService;
 import leets.bookmark.domain.notification.domain.service.NotificationDeleteService;
 import leets.bookmark.domain.notification.domain.service.NotificationGetService;
 import leets.bookmark.domain.user.domain.entity.User;
@@ -45,7 +44,6 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import leets.bookmark.domain.bookmark.domain.service.BookmarkDeleteService;
 import leets.bookmark.domain.bookmark.domain.service.BookmarkSaveService;
-import leets.bookmark.domain.bookmark.domain.service.BookmarkUpdateService;
 import org.springframework.stereotype.Service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
@@ -58,7 +56,6 @@ public class BookmarkUseCaseImpl implements BookmarkUseCase {
     private final BookmarkMapper bookmarkMapper;
     private final BookmarkDeleteService bookmarkDeleteService;
     private final BookmarkSaveService bookmarkSaveService;
-    private final BookmarkUpdateService bookmarkUpdateService;
     private final UserGetService userGetService;
     private final BookmarkPreviewService bookmarkPreviewService;
 
@@ -67,12 +64,10 @@ public class BookmarkUseCaseImpl implements BookmarkUseCase {
 
     private final BookmarkSearchConditionMapper bookmarkSearchConditionMapper;
     private final FileUseCase fileUseCase;
-    private final NotificationUseCase notificationUseCase;
     private final NotificationDeleteService notificationDeleteService;
     private final NotificationGetService notificationGetService;
 
     private final FileMapper fileMapper;
-    private final FileGetService fileGetService;
 
     private final BookmarkTagMappingRepository bookmarkTagMappingRepository;
     private final BookmarkPlatformMapper bookmarkPlatformMapper;

--- a/src/main/java/leets/bookmark/domain/bookmark/domain/repository/BookmarkRepository.java
+++ b/src/main/java/leets/bookmark/domain/bookmark/domain/repository/BookmarkRepository.java
@@ -2,6 +2,7 @@ package leets.bookmark.domain.bookmark.domain.repository;
 
 import leets.bookmark.domain.bookmark.domain.entity.Bookmark;
 import leets.bookmark.domain.category.domain.entity.Category;
+import leets.bookmark.domain.user.domain.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -11,4 +12,6 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long>, Bookm
     List<Bookmark> findTop3ByCategoryOrderByCreatedAtDesc(Category category);
 
     List<Bookmark> findAllByCategory(Category category);
+
+    List<Bookmark> findAllByUserOrderByCreatedAtDesc(User user);
 }

--- a/src/main/java/leets/bookmark/domain/bookmark/domain/service/BookmarkGetService.java
+++ b/src/main/java/leets/bookmark/domain/bookmark/domain/service/BookmarkGetService.java
@@ -2,12 +2,14 @@ package leets.bookmark.domain.bookmark.domain.service;
 
 import leets.bookmark.domain.bookmark.application.dto.request.BookmarkSearchCondition;
 import leets.bookmark.domain.bookmark.application.exception.BookmarkNotFoundException;
+import leets.bookmark.domain.bookmark.application.mapper.BookmarkPlatformMapper;
 import leets.bookmark.domain.bookmark.domain.entity.Bookmark;
 import leets.bookmark.domain.bookmark.domain.entity.BookmarkTagMapping;
 import leets.bookmark.domain.bookmark.domain.repository.BookmarkRepository;
 import leets.bookmark.domain.bookmark.domain.repository.BookmarkTagMappingRepository;
 import leets.bookmark.domain.category.domain.entity.Category;
 import leets.bookmark.domain.tag.domain.entity.Tag;
+import leets.bookmark.domain.user.domain.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -21,6 +23,7 @@ public class BookmarkGetService {
 
     private final BookmarkRepository bookmarkRepository;
     private final BookmarkTagMappingRepository bookmarkTagMappingRepository;
+    private final BookmarkPlatformMapper bookmarkPlatformMapper;
 
     public List<BookmarkTagMapping> getMappingsByBookmark(Bookmark bookmark) {
         return bookmarkTagMappingRepository.findAllByBookmarkId(bookmark.getId());
@@ -45,5 +48,10 @@ public class BookmarkGetService {
 
     public List<Bookmark> getBookmarksByCategory(Category category) {
         return bookmarkRepository.findAllByCategory(category);
+    }
+
+    public List<Bookmark> getDistinctPlatformsByUser(User user) {
+        List<Bookmark> bookmarks = bookmarkRepository.findAllByUserOrderByCreatedAtDesc(user);
+        return bookmarkPlatformMapper.toBookmarkPlatformList(bookmarks);
     }
 }

--- a/src/main/java/leets/bookmark/domain/bookmark/presentation/BookmarkPlatformController.java
+++ b/src/main/java/leets/bookmark/domain/bookmark/presentation/BookmarkPlatformController.java
@@ -1,0 +1,32 @@
+package leets.bookmark.domain.bookmark.presentation;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import leets.bookmark.domain.bookmark.application.dto.response.BookmarkPlatformResponse;
+import leets.bookmark.domain.bookmark.application.usecase.BookmarkUseCase;
+import leets.bookmark.global.auth.annotation.CurrentUser;
+import leets.bookmark.global.common.response.CommonResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+import static leets.bookmark.domain.bookmark.presentation.BookmarkResponseMessage.*;
+
+@Tag(name = "PLATFORM", description = "북마크 플랫폼 관련 API")
+@RestController
+@RequestMapping("/api/v1/platforms")
+@RequiredArgsConstructor
+public class BookmarkPlatformController {
+
+    private final BookmarkUseCase bookmarkUseCase;
+
+    @GetMapping
+    @Operation(summary = "플랫폼 조회 API", description = "사용자가 저장한 북마크의 플랫폼을 조회할 수 있는 API입니다.")
+    public CommonResponse<List<BookmarkPlatformResponse>> getAllPlatforms(@CurrentUser Long userId) {
+        List<BookmarkPlatformResponse> response = bookmarkUseCase.getAllPlatforms(userId);
+        return CommonResponse.createSuccess(GET_ALL_BOOKMARK_PLATFORMS_SUCCESS.getMessage(), response);
+    }
+}

--- a/src/main/java/leets/bookmark/domain/bookmark/presentation/BookmarkResponseMessage.java
+++ b/src/main/java/leets/bookmark/domain/bookmark/presentation/BookmarkResponseMessage.java
@@ -12,7 +12,9 @@ public enum BookmarkResponseMessage {
     BOOKMARK_DELETE_SUCCESS("북마크 삭제에 성공했습니다."),
     BOOKMARK_UPDATE_SUCCESS("북마크 수정에 성공했습니다."),
     BOOKMARK_SAVE_SUCCESS("북마크 저장에 성공하였습니다."),
-    BOOKMARK_PREVIEW_SUCCESS("썸네일, 제목, 파비콘, 플랫폼 추출에 성공했습니다.");
+    BOOKMARK_PREVIEW_SUCCESS("썸네일, 제목, 파비콘, 플랫폼 추출에 성공했습니다."),
+
+    GET_ALL_BOOKMARK_PLATFORMS_SUCCESS("플랫폼 조회에 성공했습니다.");
 
     private final String message;
 }

--- a/src/main/java/leets/bookmark/domain/category/application/dto/response/CategoryWithTagResponse.java
+++ b/src/main/java/leets/bookmark/domain/category/application/dto/response/CategoryWithTagResponse.java
@@ -1,6 +1,5 @@
 package leets.bookmark.domain.category.application.dto.response;
 
-import leets.bookmark.domain.bookmark.domain.entity.enums.Platform;
 import leets.bookmark.domain.tag.application.dto.response.TagResponse;
 import lombok.Builder;
 
@@ -11,6 +10,6 @@ public record CategoryWithTagResponse(
         Long categoryId,
         String categoryName,
         List<TagResponse> tags,
-        List<Platform> platforms
+        List<String> platforms
 ) {
 }

--- a/src/main/java/leets/bookmark/domain/category/application/mapper/CategoryMapper.java
+++ b/src/main/java/leets/bookmark/domain/category/application/mapper/CategoryMapper.java
@@ -50,12 +50,15 @@ public class CategoryMapper {
 
     public CategoryWithTagResponse toCategoryWithTagResponse(Category category, List<Tag> tags, List<Platform> platforms) {
         List<TagResponse> tagResponse = tagMapper.toTagResponseList(tags);
+        List<String> platformNames = platforms.stream()
+                .map(Platform::getPlatformName)
+                .toList();
 
         return CategoryWithTagResponse.builder()
                 .categoryId(category.getId())
                 .categoryName(category.getCategoryName())
                 .tags(tagResponse)
-                .platforms(platforms)
+                .platforms(platformNames)
                 .build();
     }
 


### PR DESCRIPTION
## ✨ 관련 이슈

- Resolved: #74 

## 🔎 작업 내용

- 플랫폼 조회 기능 추가
  - 사용자가 저장한 북마크에서 사용된 플랫폼 목록을 조회하는 로직 추가했습니다.
  - 중복되지 않게 1개씩 반환됩니다.
  - 중복될 경우 가장 마지막에 저장된 favicon url을 불러옵니다.

<br>


## 📌 참고 사항

- 기타 안내 사항 <!--(선택 사항)-->
  - 카테고리 전체 조회 시 플랫폼이 ENUM으로 반환되었습니다. 플랫폼명이 반환되도록 수정했습니다. (예: NAVER → 네이버)


<br>

## 📷 이미지 첨부
- 플랫폼 조회 테스트입니다.
<br>
<img width="758" height="416" alt="플랫폼 목록 조회" src="https://github.com/user-attachments/assets/4a974ffb-ee25-4044-ae3b-5c976edc2f15" />

<br>

- 변경된 카테고리 및 태그 전체 조회 반환값입니다.
<img width="758" height="577" alt="스크린샷 2025-08-02 오후 9 52 35" src="https://github.com/user-attachments/assets/d76cf2ef-0e3e-4571-b4d0-43ca33f3cfe6" />


<br/>

---

## ✅ Check List
- [x] 라벨 지정
- [x] 리뷰어 지정
- [x] 담당자 지정
- [x] 테스트 완료
- [x] 이슈 제목 컨벤션 준수
- [x] PR 제목 및 설명 작성
- [x] 커밋 메시지 컨벤션 준수
