### PR TITLE
Hotfix #78 url 길이 제한 수정

### DIFF
--- a/src/main/java/leets/bookmark/domain/bookmark/domain/entity/Bookmark.java
+++ b/src/main/java/leets/bookmark/domain/bookmark/domain/entity/Bookmark.java
@@ -1,17 +1,15 @@
 package leets.bookmark.domain.bookmark.domain.entity;
 
 import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
 import leets.bookmark.domain.bookmark.domain.entity.enums.Platform;
 import leets.bookmark.domain.category.domain.entity.Category;
 import leets.bookmark.domain.file.domain.entity.File;
-import leets.bookmark.domain.tag.domain.entity.Tag;
 import leets.bookmark.domain.user.domain.entity.User;
 import leets.bookmark.global.common.entity.BaseTimeEntity;
 
 import lombok.*;
 
-import java.util.ArrayList;
-import java.util.List;
 
 @Entity
 @Table(name = "bookmarks")
@@ -26,6 +24,8 @@ public class Bookmark extends BaseTimeEntity {
     @Column(name = "bookmark_id")
     private Long id;
 
+    @NotNull
+    @Column(nullable = false, length = 1024)
     private String url;
 
     private String title;

--- a/src/main/java/leets/bookmark/domain/file/application/usecase/FileUseCase.java
+++ b/src/main/java/leets/bookmark/domain/file/application/usecase/FileUseCase.java
@@ -40,8 +40,13 @@ public class FileUseCase {
 
     @Transactional
     public void saveFile(User user, Bookmark bookmark, @Valid FileSaveRequest fileSaveRequest) {
-        File file = fileMapper.toFile(user, bookmark, fileSaveRequest,
-                getValidatedFileType(fileSaveRequest.fileName()));
+        FileType fileNameType = getValidatedFileType(fileSaveRequest.fileName());
+        FileType fileUrlType = getValidatedFileType(fileSaveRequest.fileUrl());
+        if (!fileNameType.equals(fileUrlType)){
+            throw new InvalidFileExtensionException();
+        }
+
+        File file = fileMapper.toFile(user, bookmark, fileSaveRequest, fileUrlType);
         fileSaveService.save(file);
     }
 

--- a/src/main/java/leets/bookmark/domain/file/domain/entity/File.java
+++ b/src/main/java/leets/bookmark/domain/file/domain/entity/File.java
@@ -37,7 +37,7 @@ public class File extends BaseTimeEntity {
     String fileName;
 
     @NotNull
-    @Column(nullable = false)
+    @Column(nullable = false, length = 1024)
     String fileUrl;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/leets/bookmark/domain/file/domain/entity/enums/FileType.java
+++ b/src/main/java/leets/bookmark/domain/file/domain/entity/enums/FileType.java
@@ -17,7 +17,8 @@ public enum FileType {
     DOCX(".docx"),
     PPTX(".pptx"),
     PPT(".ppt"),
-    TXT(".txt");
+    TXT(".txt"),
+    WEBP(".webp");
 
     private final String extension;
 


### PR DESCRIPTION
## ✨ 관련 이슈

- Resolved: #78 

## 🔎 작업 내용

- 북마크와 파일의 url 길이 제한을 1024으로 수정
- 파일 확장자 타입에 .webp 추가
- 파일의 이름과 url의 확장자 비교 로직 추가

예외 처리되는 경우
- 파일의 name과 url 확장자가 다를 경우
- 확장자가 FileType에 명시되지 않은 경우

<br>

<br>

## 📷 이미지 첨부
- 파일의 name과 url의 확장자가 다른 경우
<img width="719" height="223" alt="image" src="https://github.com/user-attachments/assets/acce24e6-17e0-4536-9d1b-6ba9a801db01" />

<br/>

---

## ✅ Check List
- [x] 라벨 지정
- [x] 리뷰어 지정
- [x] 담당자 지정
- [x] 테스트 완료
- [x] 이슈 제목 컨벤션 준수
- [x] PR 제목 및 설명 작성
- [x] 커밋 메시지 컨벤션 준수
