### PR TITLE
Feat #80 Pre-signed URL 파일 확장자 추출 메소드 로직 수정

### DIFF
--- a/src/main/java/leets/bookmark/domain/file/application/usecase/FileUseCase.java
+++ b/src/main/java/leets/bookmark/domain/file/application/usecase/FileUseCase.java
@@ -35,6 +35,7 @@ public class FileUseCase {
     private final PreSignedMapper preSignedMapper;
 
     public PresignedUrlResponse getPreSignedUrl(String fileName) {
+        fileName = extractFileNameWithExtension(fileName);
         return preSignedMapper.toResponse(fileName, preSignedService.createPresignedUrl(fileName));
     }
 
@@ -89,6 +90,16 @@ public class FileUseCase {
 
     private FileType getValidatedFileType(String fileName){
        return FileType.fromExtension(getExtension(getExtension(fileName)))
+                .orElseThrow(InvalidFileExtensionException::new);
+    }
+
+    public String extractFileNameWithExtension(String fileName) {
+        return FileType.fromFileName(fileName)
+                .map(fileType -> {
+                    String lowerFileName = fileName.toLowerCase();
+                    return fileName.substring(0,
+                            lowerFileName.lastIndexOf(fileType.getExtension()) + fileType.getExtension().length());
+                })
                 .orElseThrow(InvalidFileExtensionException::new);
     }
 

--- a/src/main/java/leets/bookmark/domain/file/domain/entity/enums/FileType.java
+++ b/src/main/java/leets/bookmark/domain/file/domain/entity/enums/FileType.java
@@ -3,6 +3,7 @@ package leets.bookmark.domain.file.domain.entity.enums;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+import java.util.Comparator;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -29,5 +30,11 @@ public enum FileType {
         return Stream.of(FileType.values())
                 .filter(fileType -> fileType.getExtension().equalsIgnoreCase(ext))
                 .findFirst();
+    }
+
+    public static Optional<FileType> fromFileName(String fileName) {
+        return Stream.of(FileType.values())
+                .filter(fileType -> fileName.toLowerCase().contains(fileType.getExtension()))
+                .max(Comparator.comparingInt(fileType -> fileName.toLowerCase().lastIndexOf(fileType.getExtension())));
     }
 }


### PR DESCRIPTION
## ✨ 관련 이슈

- Resolved: #80 

## 🔎 작업 내용

- Pre-signed URL에서 파일 확장자가 중간에 포함된 경우 처리 로직 수정

<br>


<!-- 내용이 없을 경우 해당 항목은 삭제해 주세요 -->

<br>

## 📷 이미지 첨부
- 확장자가 중간에 포함된 경우
<br>
<img width="1009" height="364" alt="image" src="https://github.com/user-attachments/assets/c290df5a-6162-4d2d-9955-048c6886bef4" />

<br/>

---

## ✅ Check List
- [x] 라벨 지정
- [x] 리뷰어 지정
- [x] 담당자 지정
- [x] 테스트 완료
- [x] 이슈 제목 컨벤션 준수
- [x] PR 제목 및 설명 작성
- [x] 커밋 메시지 컨벤션 준수
