### PR TITLE
Feat #82 카테고리 삭제 로직 변경

### DIFF
--- a/src/main/java/leets/bookmark/domain/bookmark/domain/repository/BookmarkTagMappingRepository.java
+++ b/src/main/java/leets/bookmark/domain/bookmark/domain/repository/BookmarkTagMappingRepository.java
@@ -21,4 +21,6 @@ public interface BookmarkTagMappingRepository extends JpaRepository<BookmarkTagM
     List<BookmarkTagMapping> findAllByTag(Tag tag);
 
     void deleteByBookmarkIn(Collection<Bookmark> bookmarks);
+
+    void deleteByTag(Tag tag);
 }

--- a/src/main/java/leets/bookmark/domain/bookmark/domain/repository/BookmarkTagMappingRepository.java
+++ b/src/main/java/leets/bookmark/domain/bookmark/domain/repository/BookmarkTagMappingRepository.java
@@ -5,6 +5,7 @@ import leets.bookmark.domain.bookmark.domain.entity.Bookmark;
 import leets.bookmark.domain.tag.domain.entity.Tag;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Collection;
 import java.util.List;
 
 public interface BookmarkTagMappingRepository extends JpaRepository<BookmarkTagMapping, Long> {
@@ -18,4 +19,6 @@ public interface BookmarkTagMappingRepository extends JpaRepository<BookmarkTagM
     void deleteByBookmarkId(Long bookmarkId);
 
     List<BookmarkTagMapping> findAllByTag(Tag tag);
+
+    void deleteByBookmarkIn(Collection<Bookmark> bookmarks);
 }

--- a/src/main/java/leets/bookmark/domain/bookmark/domain/service/BookmarkDeleteService.java
+++ b/src/main/java/leets/bookmark/domain/bookmark/domain/service/BookmarkDeleteService.java
@@ -1,7 +1,5 @@
 package leets.bookmark.domain.bookmark.domain.service;
 
-
-import org.springframework.transaction.annotation.Transactional;
 import leets.bookmark.domain.bookmark.domain.entity.Bookmark;
 import leets.bookmark.domain.bookmark.domain.repository.BookmarkRepository;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/leets/bookmark/domain/bookmark/domain/service/BookmarkDeleteService.java
+++ b/src/main/java/leets/bookmark/domain/bookmark/domain/service/BookmarkDeleteService.java
@@ -2,17 +2,32 @@ package leets.bookmark.domain.bookmark.domain.service;
 
 import leets.bookmark.domain.bookmark.domain.entity.Bookmark;
 import leets.bookmark.domain.bookmark.domain.repository.BookmarkRepository;
+import leets.bookmark.domain.bookmark.domain.repository.BookmarkTagMappingRepository;
+import leets.bookmark.domain.file.domain.service.FileDeleteService;
+import leets.bookmark.domain.notification.domain.service.NotificationDeleteService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class BookmarkDeleteService {
 
     private final BookmarkRepository bookmarkRepository;
+    private final FileDeleteService fileDeleteService;
+    private final BookmarkTagMappingRepository bookmarkTagMappingRepository;
+    private final NotificationDeleteService notificationDeleteService;
 
     public void delete(final Bookmark bookmark) {
         bookmarkRepository.delete(bookmark);
     }
 
+    public void deleteAllBookmarks(List<Bookmark> bookmarks) {
+        bookmarks.forEach(Bookmark::deleteFile);
+        fileDeleteService.deleteByBookmarks(bookmarks);
+        bookmarkTagMappingRepository.deleteByBookmarkIn(bookmarks);
+        notificationDeleteService.deleteByBookmarks(bookmarks);
+        bookmarkRepository.deleteAll(bookmarks);
+    }
 }

--- a/src/main/java/leets/bookmark/domain/bookmark/domain/service/BookmarkDeleteService.java
+++ b/src/main/java/leets/bookmark/domain/bookmark/domain/service/BookmarkDeleteService.java
@@ -2,7 +2,6 @@ package leets.bookmark.domain.bookmark.domain.service;
 
 import leets.bookmark.domain.bookmark.domain.entity.Bookmark;
 import leets.bookmark.domain.bookmark.domain.repository.BookmarkRepository;
-import leets.bookmark.domain.bookmark.domain.repository.BookmarkTagMappingRepository;
 import leets.bookmark.domain.file.domain.service.FileDeleteService;
 import leets.bookmark.domain.notification.domain.service.NotificationDeleteService;
 import lombok.RequiredArgsConstructor;
@@ -16,8 +15,8 @@ public class BookmarkDeleteService {
 
     private final BookmarkRepository bookmarkRepository;
     private final FileDeleteService fileDeleteService;
-    private final BookmarkTagMappingRepository bookmarkTagMappingRepository;
     private final NotificationDeleteService notificationDeleteService;
+    private final BookmarkTagDeleteService bookmarkTagDeleteService;
 
     public void delete(final Bookmark bookmark) {
         bookmarkRepository.delete(bookmark);
@@ -26,7 +25,7 @@ public class BookmarkDeleteService {
     public void deleteAllBookmarks(List<Bookmark> bookmarks) {
         bookmarks.forEach(Bookmark::deleteFile);
         fileDeleteService.deleteByBookmarks(bookmarks);
-        bookmarkTagMappingRepository.deleteByBookmarkIn(bookmarks);
+        bookmarkTagDeleteService.deleteAllByBookmarks(bookmarks);
         notificationDeleteService.deleteByBookmarks(bookmarks);
         bookmarkRepository.deleteAll(bookmarks);
     }

--- a/src/main/java/leets/bookmark/domain/bookmark/domain/service/BookmarkTagDeleteService.java
+++ b/src/main/java/leets/bookmark/domain/bookmark/domain/service/BookmarkTagDeleteService.java
@@ -1,0 +1,24 @@
+package leets.bookmark.domain.bookmark.domain.service;
+
+import leets.bookmark.domain.bookmark.domain.entity.Bookmark;
+import leets.bookmark.domain.bookmark.domain.repository.BookmarkTagMappingRepository;
+import leets.bookmark.domain.tag.domain.entity.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class BookmarkTagDeleteService {
+
+    private final BookmarkTagMappingRepository bookmarkTagMappingRepository;
+
+    public void deleteAllByBookmarks(List<Bookmark> bookmarks) {
+        bookmarkTagMappingRepository.deleteByBookmarkIn(bookmarks);
+    }
+
+    public void deleteByTag(Tag tag) {
+        bookmarkTagMappingRepository.deleteByTag(tag);
+    }
+}

--- a/src/main/java/leets/bookmark/domain/category/application/usecase/CategoryUseCaseImpl.java
+++ b/src/main/java/leets/bookmark/domain/category/application/usecase/CategoryUseCaseImpl.java
@@ -1,8 +1,9 @@
 package leets.bookmark.domain.category.application.usecase;
 
 import leets.bookmark.domain.bookmark.application.mapper.BookmarkCategoryMapper;
-import leets.bookmark.domain.bookmark.application.usecase.BookmarkUseCase;
+import leets.bookmark.domain.bookmark.domain.entity.Bookmark;
 import leets.bookmark.domain.bookmark.domain.entity.enums.Platform;
+import leets.bookmark.domain.bookmark.domain.service.BookmarkDeleteService;
 import leets.bookmark.domain.bookmark.domain.service.BookmarkGetService;
 import leets.bookmark.domain.category.application.dto.request.CategoryCreateRequest;
 import leets.bookmark.domain.category.application.dto.request.CategoryNameUpdateRequest;
@@ -43,11 +44,10 @@ public class CategoryUseCaseImpl implements CategoryUseCase {
     private final TagGetService tagGetService;
     private final TagDeleteService tagDeleteService;
     private final BookmarkGetService bookmarkGetService;
+    private final BookmarkDeleteService bookmarkDeleteService;
 
     private final CategoryMapper categoryMapper;
     private final BookmarkCategoryMapper bookmarkCategoryMapper;
-
-    private final BookmarkUseCase bookmarkUseCase;
 
     @Transactional
     @Override
@@ -104,8 +104,9 @@ public class CategoryUseCaseImpl implements CategoryUseCase {
 
         validateCategoryOwner(category, user);
 
-        bookmarkGetService.getBookmarksByCategory(category)
-                        .forEach(bookmark -> bookmarkUseCase.delete(user.getId(), bookmark.getId()));
+        List<Bookmark> bookmarks = bookmarkGetService.getBookmarksByCategory(category);
+        bookmarkDeleteService.deleteAllBookmarks(bookmarks);
+
         tagDeleteService.deleteAllByCategory(category);
         categoryDeleteService.delete(categoryId);
     }

--- a/src/main/java/leets/bookmark/domain/category/application/usecase/CategoryUseCaseImpl.java
+++ b/src/main/java/leets/bookmark/domain/category/application/usecase/CategoryUseCaseImpl.java
@@ -1,13 +1,13 @@
 package leets.bookmark.domain.category.application.usecase;
 
 import leets.bookmark.domain.bookmark.application.mapper.BookmarkCategoryMapper;
+import leets.bookmark.domain.bookmark.application.usecase.BookmarkUseCase;
 import leets.bookmark.domain.bookmark.domain.entity.enums.Platform;
 import leets.bookmark.domain.bookmark.domain.service.BookmarkGetService;
 import leets.bookmark.domain.category.application.dto.request.CategoryCreateRequest;
 import leets.bookmark.domain.category.application.dto.request.CategoryNameUpdateRequest;
 import leets.bookmark.domain.category.application.dto.response.CategoryResponse;
 import leets.bookmark.domain.category.application.dto.response.CategoryWithTagResponse;
-import leets.bookmark.domain.category.application.exception.CategoryHasBookmarksException;
 import leets.bookmark.domain.category.application.exception.CategoryLimitExceedException;
 import leets.bookmark.domain.category.application.exception.CategoryOwnerMismatchException;
 import leets.bookmark.domain.category.application.exception.DuplicatedCategoryNameException;
@@ -46,6 +46,8 @@ public class CategoryUseCaseImpl implements CategoryUseCase {
 
     private final CategoryMapper categoryMapper;
     private final BookmarkCategoryMapper bookmarkCategoryMapper;
+
+    private final BookmarkUseCase bookmarkUseCase;
 
     @Transactional
     @Override
@@ -101,8 +103,9 @@ public class CategoryUseCaseImpl implements CategoryUseCase {
         Category category = categoryGetService.findById(categoryId);
 
         validateCategoryOwner(category, user);
-        checkCategoryIsEmpty(category);
 
+        bookmarkGetService.getBookmarksByCategory(category)
+                        .forEach(bookmark -> bookmarkUseCase.delete(user.getId(), bookmark.getId()));
         tagDeleteService.deleteAllByCategory(category);
         categoryDeleteService.delete(categoryId);
     }
@@ -122,12 +125,6 @@ public class CategoryUseCaseImpl implements CategoryUseCase {
     private void checkExceededCategoryLimit(User user) {
         if (categoryGetService.countByUser(user) >= CATEGORY_LIMIT) {
             throw new CategoryLimitExceedException();
-        }
-    }
-
-    private void checkCategoryIsEmpty(Category category) {
-        if (!bookmarkGetService.getBookmarksByCategory(category).isEmpty()) {
-            throw new CategoryHasBookmarksException();
         }
     }
 }

--- a/src/main/java/leets/bookmark/domain/file/domain/repository/FileRepository.java
+++ b/src/main/java/leets/bookmark/domain/file/domain/repository/FileRepository.java
@@ -1,11 +1,15 @@
 package leets.bookmark.domain.file.domain.repository;
 
+import leets.bookmark.domain.bookmark.domain.entity.Bookmark;
 import leets.bookmark.domain.file.domain.entity.File;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Collection;
 import java.util.Optional;
 
 public interface FileRepository extends JpaRepository<File, Long> {
 
     Optional<File> findByBookmarkId(Long bookmarkId);
+
+    void deleteByBookmarkIn(Collection<Bookmark> bookmarks);
 }

--- a/src/main/java/leets/bookmark/domain/file/domain/service/FileDeleteService.java
+++ b/src/main/java/leets/bookmark/domain/file/domain/service/FileDeleteService.java
@@ -1,9 +1,12 @@
 package leets.bookmark.domain.file.domain.service;
 
+import leets.bookmark.domain.bookmark.domain.entity.Bookmark;
 import leets.bookmark.domain.file.domain.entity.File;
 import leets.bookmark.domain.file.domain.repository.FileRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @Service
@@ -13,5 +16,9 @@ public class FileDeleteService {
 
     public void delete(File file) {
         fileRepository.delete(file);
+    }
+
+    public void deleteByBookmarks(List<Bookmark> bookmarks) {
+        fileRepository.deleteByBookmarkIn(bookmarks);
     }
 }

--- a/src/main/java/leets/bookmark/domain/notification/domain/repository/NotificationRepository.java
+++ b/src/main/java/leets/bookmark/domain/notification/domain/repository/NotificationRepository.java
@@ -1,10 +1,12 @@
 package leets.bookmark.domain.notification.domain.repository;
 
+import leets.bookmark.domain.bookmark.domain.entity.Bookmark;
 import leets.bookmark.domain.notification.domain.entity.Notification;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -13,4 +15,6 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     Optional<Notification> findByBookmarkId(Long bookmarkId);
 
     List<Notification> findAllByIsNotifiedFalseAndNotifyAtBetween(LocalDateTime from, LocalDateTime to);
+
+    void deleteByBookmarkIn(Collection<Bookmark> bookmarks);
 }

--- a/src/main/java/leets/bookmark/domain/notification/domain/service/NotificationDeleteService.java
+++ b/src/main/java/leets/bookmark/domain/notification/domain/service/NotificationDeleteService.java
@@ -1,9 +1,12 @@
 package leets.bookmark.domain.notification.domain.service;
 
+import leets.bookmark.domain.bookmark.domain.entity.Bookmark;
 import leets.bookmark.domain.notification.domain.entity.Notification;
 import leets.bookmark.domain.notification.domain.repository.NotificationRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @Service
@@ -13,5 +16,9 @@ public class NotificationDeleteService {
 
     public void delete(Notification notification){
         notificationRepository.delete(notification);
+    }
+
+    public void deleteByBookmarks(List<Bookmark> bookmarks) {
+        notificationRepository.deleteByBookmarkIn(bookmarks);
     }
 }

--- a/src/main/java/leets/bookmark/domain/tag/application/exception/TagErrorCode.java
+++ b/src/main/java/leets/bookmark/domain/tag/application/exception/TagErrorCode.java
@@ -12,7 +12,7 @@ public enum TagErrorCode implements ErrorCode {
     DUPLICATED_TAG_NAME_EXCEPTION(400, "이미 존재하는 태그입니다."),
     TAG_OWNER_MISMATCH_EXCEPTION(403, "해당 태그 소유자만 접근 가능합니다."),
     TAG_LIMIT_EXCEED_EXCEPTION(400, "태그는 카테고리당 최대 10개까지 생성 가능합니다."),
-    TAG_HAS_BOOKMARK_EXCEPTION(400, "해당 태그에 북마크가 존재합니다.");
+    TAG_HAS_BOOKMARK_EXCEPTION(400, "해당 태그를 유일하게 사용하고 있는 북마크가 존재합니다.");
 
     private final int errorCode;
     private final String message;

--- a/src/main/java/leets/bookmark/domain/tag/application/exception/TagErrorCode.java
+++ b/src/main/java/leets/bookmark/domain/tag/application/exception/TagErrorCode.java
@@ -12,7 +12,7 @@ public enum TagErrorCode implements ErrorCode {
     DUPLICATED_TAG_NAME_EXCEPTION(400, "이미 존재하는 태그입니다."),
     TAG_OWNER_MISMATCH_EXCEPTION(403, "해당 태그 소유자만 접근 가능합니다."),
     TAG_LIMIT_EXCEED_EXCEPTION(400, "태그는 카테고리당 최대 10개까지 생성 가능합니다."),
-    TAG_HAS_BOOKMARK_EXCEPTION(400, "해당 태그를 유일하게 사용하고 있는 북마크가 존재합니다.");
+    TAG_ONLY_USED_EXCEPTION(400, "해당 태그를 유일하게 사용하고 있는 북마크가 존재합니다.");
 
     private final int errorCode;
     private final String message;

--- a/src/main/java/leets/bookmark/domain/tag/application/exception/TagErrorCode.java
+++ b/src/main/java/leets/bookmark/domain/tag/application/exception/TagErrorCode.java
@@ -12,7 +12,8 @@ public enum TagErrorCode implements ErrorCode {
     DUPLICATED_TAG_NAME_EXCEPTION(400, "이미 존재하는 태그입니다."),
     TAG_OWNER_MISMATCH_EXCEPTION(403, "해당 태그 소유자만 접근 가능합니다."),
     TAG_LIMIT_EXCEED_EXCEPTION(400, "태그는 카테고리당 최대 10개까지 생성 가능합니다."),
-    TAG_ONLY_USED_EXCEPTION(400, "해당 태그를 유일하게 사용하고 있는 북마크가 존재합니다.");
+
+    TAG_ONLY_USED_BOOKMARK_EXISTS(400, "해당 태그를 유일하게 사용하고 있는 북마크가 존재합니다.");
 
     private final int errorCode;
     private final String message;

--- a/src/main/java/leets/bookmark/domain/tag/application/exception/TagHasBookmarksException.java
+++ b/src/main/java/leets/bookmark/domain/tag/application/exception/TagHasBookmarksException.java
@@ -1,9 +1,0 @@
-package leets.bookmark.domain.tag.application.exception;
-
-import leets.bookmark.global.common.exception.BusinessException;
-
-public class TagHasBookmarksException extends BusinessException {
-    public TagHasBookmarksException() {
-        super(TagErrorCode.TAG_HAS_BOOKMARK_EXCEPTION);
-    }
-}

--- a/src/main/java/leets/bookmark/domain/tag/application/exception/TagOnlyUsedException.java
+++ b/src/main/java/leets/bookmark/domain/tag/application/exception/TagOnlyUsedException.java
@@ -1,0 +1,9 @@
+package leets.bookmark.domain.tag.application.exception;
+
+import leets.bookmark.global.common.exception.BusinessException;
+
+public class TagOnlyUsedException extends BusinessException {
+    public TagOnlyUsedException() {
+        super(TagErrorCode.TAG_ONLY_USED_EXCEPTION);
+    }
+}

--- a/src/main/java/leets/bookmark/domain/tag/application/exception/TagOnlyUsedException.java
+++ b/src/main/java/leets/bookmark/domain/tag/application/exception/TagOnlyUsedException.java
@@ -4,6 +4,6 @@ import leets.bookmark.global.common.exception.BusinessException;
 
 public class TagOnlyUsedException extends BusinessException {
     public TagOnlyUsedException() {
-        super(TagErrorCode.TAG_ONLY_USED_EXCEPTION);
+        super(TagErrorCode.TAG_ONLY_USED_BOOKMARK_EXISTS);
     }
 }

--- a/src/main/java/leets/bookmark/domain/tag/application/usecase/TagUseCaseImpl.java
+++ b/src/main/java/leets/bookmark/domain/tag/application/usecase/TagUseCaseImpl.java
@@ -10,7 +10,7 @@ import leets.bookmark.domain.tag.application.dto.request.TagCreateRequest;
 import leets.bookmark.domain.tag.application.dto.request.TagNameUpdateRequest;
 import leets.bookmark.domain.tag.application.dto.response.TagResponse;
 import leets.bookmark.domain.tag.application.exception.DuplicatedTagNameException;
-import leets.bookmark.domain.tag.application.exception.TagHasBookmarksException;
+import leets.bookmark.domain.tag.application.exception.TagOnlyUsedException;
 import leets.bookmark.domain.tag.application.exception.TagLimitExceedException;
 import leets.bookmark.domain.tag.application.exception.TagOwnerMismatchException;
 import leets.bookmark.domain.tag.application.mapper.TagMapper;
@@ -125,7 +125,7 @@ public class TagUseCaseImpl implements TagUseCase {
             List<BookmarkTagMapping> bookmarkMappings = bookmarkGetService.getMappingsByBookmark(bookmark);
 
             if (bookmarkMappings.size() == 1) { // 북마크가 해당 태그 1개만 사용할 경우 삭제 불가
-                throw new TagHasBookmarksException();
+                throw new TagOnlyUsedException();
             }
         }
     }

--- a/src/main/java/leets/bookmark/domain/tag/application/usecase/TagUseCaseImpl.java
+++ b/src/main/java/leets/bookmark/domain/tag/application/usecase/TagUseCaseImpl.java
@@ -1,5 +1,7 @@
 package leets.bookmark.domain.tag.application.usecase;
 
+import leets.bookmark.domain.bookmark.domain.entity.Bookmark;
+import leets.bookmark.domain.bookmark.domain.entity.BookmarkTagMapping;
 import leets.bookmark.domain.bookmark.domain.service.BookmarkGetService;
 import leets.bookmark.domain.category.application.exception.CategoryOwnerMismatchException;
 import leets.bookmark.domain.category.domain.entity.Category;
@@ -37,9 +39,9 @@ public class TagUseCaseImpl implements TagUseCase {
     private final TagSaveService tagSaveService;
     private final TagUpdateService tagUpdateService;
     private final TagDeleteService tagDeleteService;
+    private final BookmarkGetService bookmarkGetService;
 
     private final TagMapper tagMapper;
-    private final BookmarkGetService bookmarkGetService;
 
     @Transactional(readOnly = true)
     @Override
@@ -86,7 +88,7 @@ public class TagUseCaseImpl implements TagUseCase {
         Tag tag = tagGetService.findById(tagId);
 
         validateTagOwner(tag, user);
-        checkTagIsEmpty(tag);
+        checkTagCanBeDeleted(tag);
 
         tagDeleteService.delete(tag);
     }
@@ -115,9 +117,16 @@ public class TagUseCaseImpl implements TagUseCase {
         }
     }
 
-    private void checkTagIsEmpty(Tag tag) {
-        if (!bookmarkGetService.getBookmarksByTag(tag).isEmpty()) {
-            throw new TagHasBookmarksException();
+    private void checkTagCanBeDeleted(Tag tag) {
+        List<BookmarkTagMapping> mappings = bookmarkGetService.getBookmarksByTag(tag);
+
+        for (BookmarkTagMapping mapping : mappings) {
+            Bookmark bookmark = mapping.getBookmark();
+            List<BookmarkTagMapping> bookmarkMappings = bookmarkGetService.getMappingsByBookmark(bookmark);
+
+            if (bookmarkMappings.size() == 1) { // 북마크가 해당 태그 1개만 사용할 경우 삭제 불가
+                throw new TagHasBookmarksException();
+            }
         }
     }
 }

--- a/src/main/java/leets/bookmark/domain/tag/domain/service/TagDeleteService.java
+++ b/src/main/java/leets/bookmark/domain/tag/domain/service/TagDeleteService.java
@@ -1,6 +1,6 @@
 package leets.bookmark.domain.tag.domain.service;
 
-import leets.bookmark.domain.bookmark.domain.repository.BookmarkTagMappingRepository;
+import leets.bookmark.domain.bookmark.domain.service.BookmarkTagDeleteService;
 import leets.bookmark.domain.category.domain.entity.Category;
 import leets.bookmark.domain.tag.domain.entity.Tag;
 import leets.bookmark.domain.tag.domain.repository.TagRepository;
@@ -12,10 +12,10 @@ import org.springframework.stereotype.Service;
 public class TagDeleteService {
 
     private final TagRepository tagRepository;
-    private final BookmarkTagMappingRepository bookmarkTagMappingRepository;
+    private final BookmarkTagDeleteService bookmarkTagDeleteService;
 
     public void delete(Tag tag) {
-        bookmarkTagMappingRepository.deleteByTag(tag);
+        bookmarkTagDeleteService.deleteByTag(tag);
         tagRepository.delete(tag);
     }
 

--- a/src/main/java/leets/bookmark/domain/tag/domain/service/TagDeleteService.java
+++ b/src/main/java/leets/bookmark/domain/tag/domain/service/TagDeleteService.java
@@ -1,5 +1,6 @@
 package leets.bookmark.domain.tag.domain.service;
 
+import leets.bookmark.domain.bookmark.domain.repository.BookmarkTagMappingRepository;
 import leets.bookmark.domain.category.domain.entity.Category;
 import leets.bookmark.domain.tag.domain.entity.Tag;
 import leets.bookmark.domain.tag.domain.repository.TagRepository;
@@ -11,8 +12,10 @@ import org.springframework.stereotype.Service;
 public class TagDeleteService {
 
     private final TagRepository tagRepository;
+    private final BookmarkTagMappingRepository bookmarkTagMappingRepository;
 
     public void delete(Tag tag) {
+        bookmarkTagMappingRepository.deleteByTag(tag);
         tagRepository.delete(tag);
     }
 


### PR DESCRIPTION
## ✨ 관련 이슈

- Resolved: #82 

## 🔎 작업 내용

- 카테고리 삭제 시 태그 및 북마크 모두 삭제되도록 수정했습니다. 상세 내용은 아래와 같습니다.
  - 기존: 북마크 존재 시 카테고리 삭제 불가
  - 수정: 해당 카테고리와 관련된 태그, 북마크, 북마크-태그매핑 삭제

- 태그 삭제 가능한 경우가 아래와 같이 변경되었습니다.
  - 기존: 북마크 존재 시 태그 삭제 불가
  - 수정
    - 해당 태그가 북마크의 유일한 태그로 사용되고 있을 경우 삭제 불가
    - 북마크가 해당 태그 외의 다른 태그도 참조 중일 경우 삭제 가능


<br>

## 📷 이미지 첨부
- 북마크 3개를 생성하였으며 모두 카테고리 ID#5를 참조합니다. 태그는 아래와 같이 참조한 상태로 테스트 진행했습니다.
  - 북마크21: **태그7 (유일한 태그) 참조**
  - 북마크22: 태그7, 8 참조
  - 북마크23: 태그7, 8, 9 참조
<br>

- 카테고리 삭제 테스트입니다.
<img width="397" height="244" alt="카테고리 삭제" src="https://github.com/user-attachments/assets/3a4a005d-5842-4580-b3b0-daa60dc068d9" />
<br>

- 태그 삭제 테스트입니다. 태그7(북마크21이 해당 태그를 유일하게 사용 중) 삭제를 시도할 경우 삭제가 불가함을 확인했습니다.
<img width="546" height="158" alt="7번태그 삭제 시도" src="https://github.com/user-attachments/assets/d628d052-59c0-47bc-ba60-f988f519da98" />
<br>

- 태그#8은 유일하게 사용되고 있지 않아서 삭제가 가능함을 확인했습니다.
<img width="546" height="158" alt="8번태그 삭제 성공" src="https://github.com/user-attachments/assets/aa8542df-8463-4a7d-adea-330318c9a3fa" />
<br>

- 태그 삭제 시 BookmarkTagMapping 테이블에서도 삭제됨을 확인했습니다.
<img width="397" height="199" alt="태그 삭제 시 매핑 테이블에서도 삭제" src="https://github.com/user-attachments/assets/e970b739-553c-4b78-a379-5dee5a7a2c62" />

<br/>

---

## ✅ Check List
- [x] 라벨 지정
- [x] 리뷰어 지정
- [x] 담당자 지정
- [x] 테스트 완료
- [x] 이슈 제목 컨벤션 준수
- [x] PR 제목 및 설명 작성
- [x] 커밋 메시지 컨벤션 준수
