### PR TITLE
Feat #84 S3 업로드 api 추가

### DIFF
--- a/src/main/java/leets/bookmark/domain/bookmark/application/dto/request/BookmarkSaveRequest.java
+++ b/src/main/java/leets/bookmark/domain/bookmark/application/dto/request/BookmarkSaveRequest.java
@@ -1,12 +1,9 @@
 package leets.bookmark.domain.bookmark.application.dto.request;
 
-import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import leets.bookmark.domain.bookmark.domain.entity.enums.Platform;
 import leets.bookmark.domain.notification.application.dto.request.NotificationSaveRequest;
-import leets.bookmark.domain.file.application.dto.request.FileSaveRequest;
-import leets.bookmark.domain.user.domain.entity.User;
 import lombok.Builder;
 
 
@@ -17,7 +14,7 @@ public record BookmarkSaveRequest(
     @NotBlank String title,
     @NotBlank String url,
     String memo,
-    @NotNull @Valid FileSaveRequest file,
+    @NotBlank String thumbnailUrl,
     NotificationSaveRequest notification,
     @NotNull Platform platform,
     @NotNull Long categoryId,

--- a/src/main/java/leets/bookmark/domain/bookmark/application/dto/request/BookmarkUpdateRequest.java
+++ b/src/main/java/leets/bookmark/domain/bookmark/application/dto/request/BookmarkUpdateRequest.java
@@ -12,7 +12,7 @@ public record BookmarkUpdateRequest(
         String title,
         String url,
         String memo,
-        FileUpdateRequest file,
+        String thumbnailUrl,
         NotificationUpdateRequest notification,
         Platform platform,
         Long categoryId,

--- a/src/main/java/leets/bookmark/domain/bookmark/application/usecase/BookmarkUseCaseImpl.java
+++ b/src/main/java/leets/bookmark/domain/bookmark/application/usecase/BookmarkUseCaseImpl.java
@@ -147,8 +147,8 @@ public class BookmarkUseCaseImpl implements BookmarkUseCase {
         Category category = categoryGetService.findById(request.categoryId());
         Bookmark bookmark = bookmarkSaveService.save(request, user, category);
 
-        if (request.file() != null) {
-            fileUseCase.saveFile(user, bookmark, request.file());
+        if (request.thumbnailUrl() != null) {
+            fileUseCase.saveThumbnailFile(user, bookmark, request.thumbnailUrl());
         }
     }
 
@@ -163,10 +163,12 @@ public class BookmarkUseCaseImpl implements BookmarkUseCase {
 
         if (request.title() != null && !request.title().trim().isEmpty()) {
             bookmark.updateTitle(request.title());
+            updated = true;
         }
 
-        if (request.file() != null) {
-            fileUseCase.updateFile(user, bookmark, request.file());
+        if (request.thumbnailUrl() != null) {
+            fileUseCase.updateThumbnailImage(user, bookmark, request.thumbnailUrl());
+            updated = true;
         }
 
         if (request.platform() != null) {

--- a/src/main/java/leets/bookmark/domain/bookmark/domain/service/BookmarkUpdateService.java
+++ b/src/main/java/leets/bookmark/domain/bookmark/domain/service/BookmarkUpdateService.java
@@ -27,7 +27,6 @@ public class BookmarkUpdateService {
 
     @Transactional
     public void update(Bookmark bookmark, BookmarkUpdateRequest request) {
-        FileUpdateRequest fileRequest = request.file();
         bookmark.updateBookmark(
             request.title(),
             request.memo()

--- a/src/main/java/leets/bookmark/domain/file/application/dto/response/S3UrlResponse.java
+++ b/src/main/java/leets/bookmark/domain/file/application/dto/response/S3UrlResponse.java
@@ -1,9 +1,0 @@
-package leets.bookmark.domain.file.application.dto.response;
-
-import lombok.Builder;
-
-@Builder
-public record S3UrlResponse  (
-        String originalFileName,
-        String s3Url
-) {}

--- a/src/main/java/leets/bookmark/domain/file/application/dto/response/S3UrlResponse.java
+++ b/src/main/java/leets/bookmark/domain/file/application/dto/response/S3UrlResponse.java
@@ -1,0 +1,6 @@
+package leets.bookmark.domain.file.application.dto.response;
+
+public record S3UrlResponse  (
+        String originalFileName,
+        String s3Url
+) {}

--- a/src/main/java/leets/bookmark/domain/file/application/dto/response/S3UrlResponse.java
+++ b/src/main/java/leets/bookmark/domain/file/application/dto/response/S3UrlResponse.java
@@ -1,5 +1,8 @@
 package leets.bookmark.domain.file.application.dto.response;
 
+import lombok.Builder;
+
+@Builder
 public record S3UrlResponse  (
         String originalFileName,
         String s3Url

--- a/src/main/java/leets/bookmark/domain/file/application/exception/FileErrorCode.java
+++ b/src/main/java/leets/bookmark/domain/file/application/exception/FileErrorCode.java
@@ -10,7 +10,8 @@ public enum FileErrorCode implements ErrorCode {
 
     FILE_NOT_FOUND_EXCEPTION(404,"해당하는 파일을 찾을 수 없습니다."),
     INVALID_FILE_EXTENSION(400, "올바르지 않은 파일 확장자입니다."),
-    FILE_OWNER_MISMATCH_EXCEPTION(403, "파일 소유자만 접근 가능합니다");
+    FILE_OWNER_MISMATCH_EXCEPTION(403, "파일 소유자만 접근 가능합니다."),
+    S3_UPLOAD_EXCEPTION(500, "파일 업로드에 실패하였습니다.");
 
     private final int errorCode;
     private final String message;

--- a/src/main/java/leets/bookmark/domain/file/application/exception/S3UploadException.java
+++ b/src/main/java/leets/bookmark/domain/file/application/exception/S3UploadException.java
@@ -1,0 +1,9 @@
+package leets.bookmark.domain.file.application.exception;
+
+import leets.bookmark.global.common.exception.BusinessException;
+
+public class S3UploadException extends BusinessException {
+    public S3UploadException(){
+        super(FileErrorCode.S3_UPLOAD_EXCEPTION);
+    }
+}

--- a/src/main/java/leets/bookmark/domain/file/application/mapper/FileMapper.java
+++ b/src/main/java/leets/bookmark/domain/file/application/mapper/FileMapper.java
@@ -3,7 +3,6 @@ package leets.bookmark.domain.file.application.mapper;
 import leets.bookmark.domain.bookmark.domain.entity.Bookmark;
 import leets.bookmark.domain.file.application.dto.request.FileSaveRequest;
 import leets.bookmark.domain.file.application.dto.response.FileResponse;
-import leets.bookmark.domain.file.application.dto.response.S3UrlResponse;
 import leets.bookmark.domain.file.domain.entity.File;
 import leets.bookmark.domain.file.domain.entity.enums.FileType;
 import leets.bookmark.domain.user.domain.entity.User;
@@ -22,10 +21,14 @@ public class FileMapper {
                 .build();
     }
 
-    public S3UrlResponse toS3UrlResponse(String s3Url, String fileUrl){
-        return S3UrlResponse.builder()
-                .s3Url(s3Url)
-                .originalFileName(fileUrl)
+    public File toThumbnailFile(User user, Bookmark bookmark, String fileName,
+                                String s3UrlResponse, FileType type) {
+        return File.builder()
+                .user(user)
+                .bookmark(bookmark)
+                .fileName(fileName)
+                .fileUrl(s3UrlResponse)
+                .fileType(type)
                 .build();
     }
 

--- a/src/main/java/leets/bookmark/domain/file/application/mapper/FileMapper.java
+++ b/src/main/java/leets/bookmark/domain/file/application/mapper/FileMapper.java
@@ -3,6 +3,7 @@ package leets.bookmark.domain.file.application.mapper;
 import leets.bookmark.domain.bookmark.domain.entity.Bookmark;
 import leets.bookmark.domain.file.application.dto.request.FileSaveRequest;
 import leets.bookmark.domain.file.application.dto.response.FileResponse;
+import leets.bookmark.domain.file.application.dto.response.S3UrlResponse;
 import leets.bookmark.domain.file.domain.entity.File;
 import leets.bookmark.domain.file.domain.entity.enums.FileType;
 import leets.bookmark.domain.user.domain.entity.User;
@@ -18,6 +19,13 @@ public class FileMapper {
                 .fileName(fileSaveRequest.fileName())
                 .fileUrl(fileSaveRequest.fileUrl())
                 .fileType(fileType)
+                .build();
+    }
+
+    public S3UrlResponse toS3UrlResponse(String s3Url, String fileUrl){
+        return S3UrlResponse.builder()
+                .s3Url(s3Url)
+                .originalFileName(fileUrl)
                 .build();
     }
 

--- a/src/main/java/leets/bookmark/domain/file/application/usecase/FileUseCase.java
+++ b/src/main/java/leets/bookmark/domain/file/application/usecase/FileUseCase.java
@@ -6,6 +6,7 @@ import leets.bookmark.domain.file.application.dto.request.FileSaveRequest;
 import leets.bookmark.domain.file.application.dto.request.FileUpdateRequest;
 import leets.bookmark.domain.file.application.dto.response.FileResponse;
 import leets.bookmark.domain.file.application.dto.response.PresignedUrlResponse;
+import leets.bookmark.domain.file.application.dto.response.S3UrlResponse;
 import leets.bookmark.domain.file.application.exception.FileOwnerMismatchException;
 import leets.bookmark.domain.file.application.exception.InvalidFileExtensionException;
 import leets.bookmark.domain.file.application.mapper.FileMapper;
@@ -103,4 +104,7 @@ public class FileUseCase {
                 .orElseThrow(InvalidFileExtensionException::new);
     }
 
+    public S3UrlResponse upload(String fileUrl) {
+        return null;
+    }
 }

--- a/src/main/java/leets/bookmark/domain/file/application/usecase/FileUseCase.java
+++ b/src/main/java/leets/bookmark/domain/file/application/usecase/FileUseCase.java
@@ -27,6 +27,7 @@ import org.springframework.validation.annotation.Validated;
 public class FileUseCase {
 
     private final PreSignedService preSignedService;
+    private final S3UploadService s3UploadService;
     private final FileSaveService fileSaveService;
     private final FileGetService fileGetService;
     private final FileUpdateService fileUpdateService;
@@ -50,6 +51,12 @@ public class FileUseCase {
 
         File file = fileMapper.toFile(user, bookmark, fileSaveRequest, fileUrlType);
         fileSaveService.save(file);
+    }
+
+    public S3UrlResponse upload(String fileUrl) {
+        fileUrl = extractFileNameWithExtension(fileUrl);
+        String s3UrlResponse = s3UploadService.upload(fileUrl);
+        return fileMapper.toS3UrlResponse(s3UrlResponse, fileUrl);
     }
 
     @Transactional(readOnly = true)
@@ -104,7 +111,4 @@ public class FileUseCase {
                 .orElseThrow(InvalidFileExtensionException::new);
     }
 
-    public S3UrlResponse upload(String fileUrl) {
-        return null;
-    }
 }

--- a/src/main/java/leets/bookmark/domain/file/application/usecase/FileUseCase.java
+++ b/src/main/java/leets/bookmark/domain/file/application/usecase/FileUseCase.java
@@ -6,7 +6,6 @@ import leets.bookmark.domain.file.application.dto.request.FileSaveRequest;
 import leets.bookmark.domain.file.application.dto.request.FileUpdateRequest;
 import leets.bookmark.domain.file.application.dto.response.FileResponse;
 import leets.bookmark.domain.file.application.dto.response.PresignedUrlResponse;
-import leets.bookmark.domain.file.application.dto.response.S3UrlResponse;
 import leets.bookmark.domain.file.application.exception.FileOwnerMismatchException;
 import leets.bookmark.domain.file.application.exception.InvalidFileExtensionException;
 import leets.bookmark.domain.file.application.mapper.FileMapper;
@@ -53,10 +52,15 @@ public class FileUseCase {
         fileSaveService.save(file);
     }
 
-    public S3UrlResponse upload(String fileUrl) {
-        fileUrl = extractFileNameWithExtension(fileUrl);
-        String s3UrlResponse = s3UploadService.upload(fileUrl);
-        return fileMapper.toS3UrlResponse(s3UrlResponse, fileUrl);
+    @Transactional
+    public void saveThumbnailFile(User user, Bookmark bookmark, String thumbnailUrl) {
+        String fileName = extractFileNameWithExtension(thumbnailUrl);
+        FileType type = getValidatedFileType(fileName);
+
+        String s3UrlResponse = s3UploadService.upload(thumbnailUrl);
+
+        File file = fileMapper.toThumbnailFile(user, bookmark, fileName, s3UrlResponse, type);
+        fileSaveService.save(file);
     }
 
     @Transactional(readOnly = true)
@@ -73,6 +77,18 @@ public class FileUseCase {
         validateFileOwner(user, file);
 
         fileUpdateService.update(file, fileUpdateRequest, getValidatedFileType(fileUpdateRequest.fileName()));
+    }
+
+    public void updateThumbnailImage(User user, Bookmark bookmark, String thumbnailUrl) {
+        File file = fileGetService.findByBookmarkId(bookmark.getId());
+        validateFileOwner(user, file);
+
+        String fileName = extractFileNameWithExtension(thumbnailUrl);
+        FileType type = getValidatedFileType(fileName);
+
+        String s3UrlResponse = s3UploadService.upload(thumbnailUrl);
+
+        fileUpdateService.updateThumbnailImage(file, fileName, s3UrlResponse, type);
     }
 
     @Transactional

--- a/src/main/java/leets/bookmark/domain/file/domain/entity/enums/FileType.java
+++ b/src/main/java/leets/bookmark/domain/file/domain/entity/enums/FileType.java
@@ -19,7 +19,8 @@ public enum FileType {
     PPTX(".pptx"),
     PPT(".ppt"),
     TXT(".txt"),
-    WEBP(".webp");
+    WEBP(".webp"),
+    HEIC(".heic");
 
     private final String extension;
 

--- a/src/main/java/leets/bookmark/domain/file/domain/service/FileUpdateService.java
+++ b/src/main/java/leets/bookmark/domain/file/domain/service/FileUpdateService.java
@@ -13,4 +13,8 @@ public class FileUpdateService {
     public void update(File file, FileUpdateRequest fileUpdateRequest, FileType fileType) {
         file.updateFile(fileUpdateRequest.fileName(), fileUpdateRequest.fileUrl(), fileType);
     }
+
+    public void updateThumbnailImage(File file, String fileName, String s3Url, FileType type) {
+        file.updateFile(fileName, s3Url, type);
+    }
 }

--- a/src/main/java/leets/bookmark/domain/file/domain/service/S3UploadService.java
+++ b/src/main/java/leets/bookmark/domain/file/domain/service/S3UploadService.java
@@ -1,0 +1,61 @@
+package leets.bookmark.domain.file.domain.service;
+
+import leets.bookmark.domain.file.application.exception.S3UploadException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.io.InputStream;
+import java.net.*;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.UUID;
+
+@RequiredArgsConstructor
+@Service
+public class S3UploadService {
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    private final S3Client s3Client;
+
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyyMMddHHmmss");
+
+    public String upload(String fileUrl) {
+        try {
+            URL url = URI.create(fileUrl).toURL();
+            HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+            connection.setRequestMethod("GET");
+
+            try (InputStream inputStream = connection.getInputStream()) {
+
+                String fileName = generateUrl(fileUrl);
+
+                PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                        .bucket(bucket)
+                        .key(fileName)
+                        .contentType(connection.getContentType())
+                        .build();
+
+                s3Client.putObject(putObjectRequest, RequestBody.fromInputStream(inputStream, connection.getContentLengthLong()));
+
+                return "https://" + bucket + ".s3." + region + ".amazonaws.com/" + fileName;
+            }
+
+        } catch (Exception e){
+            throw new S3UploadException();
+        }
+    }
+
+    private String generateUrl(String fileName) {
+        String extension = fileName.substring(fileName.lastIndexOf(".") + 1);
+        return LocalDateTime.now().format(FORMATTER) + UUID.randomUUID().toString() + "." + extension;
+    }
+}

--- a/src/main/java/leets/bookmark/domain/file/presentation/FileController.java
+++ b/src/main/java/leets/bookmark/domain/file/presentation/FileController.java
@@ -2,7 +2,6 @@ package leets.bookmark.domain.file.presentation;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
 import leets.bookmark.domain.file.application.dto.response.PresignedUrlResponse;
-import leets.bookmark.domain.file.application.dto.response.S3UrlResponse;
 import leets.bookmark.domain.file.application.usecase.FileUseCase;
 import leets.bookmark.global.common.response.CommonResponse;
 import lombok.RequiredArgsConstructor;
@@ -22,9 +21,4 @@ public class FileController {
         return CommonResponse.createSuccess(FileResponseCode.PRE_SIGNED_URL_SUCCESS.getMessage(), response);
     }
 
-    @GetMapping("/upload")
-    public CommonResponse<S3UrlResponse> getS3Url(@RequestParam String fileUrl) {
-        S3UrlResponse response = fileUseCase.upload(fileUrl);
-        return CommonResponse.createSuccess(FileResponseCode.S3_UPLOAD_SUCCESS.getMessage(), response);
-    }
 }

--- a/src/main/java/leets/bookmark/domain/file/presentation/FileController.java
+++ b/src/main/java/leets/bookmark/domain/file/presentation/FileController.java
@@ -2,6 +2,7 @@ package leets.bookmark.domain.file.presentation;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
 import leets.bookmark.domain.file.application.dto.response.PresignedUrlResponse;
+import leets.bookmark.domain.file.application.dto.response.S3UrlResponse;
 import leets.bookmark.domain.file.application.usecase.FileUseCase;
 import leets.bookmark.global.common.response.CommonResponse;
 import lombok.RequiredArgsConstructor;
@@ -19,5 +20,11 @@ public class FileController {
     public CommonResponse<PresignedUrlResponse> getPresignedUrl(@RequestParam String fileName) {
         PresignedUrlResponse response = fileUseCase.getPreSignedUrl(fileName);
         return CommonResponse.createSuccess(FileResponseCode.PRE_SIGNED_URL_SUCCESS.getMessage(), response);
+    }
+
+    @GetMapping("/upload")
+    public CommonResponse<S3UrlResponse> getS3Url(@RequestParam String fileUrl) {
+        S3UrlResponse response = fileUseCase.upload(fileUrl);
+        return CommonResponse.createSuccess(FileResponseCode.S3_UPLOAD_SUCCESS.getMessage(), response);
     }
 }

--- a/src/main/java/leets/bookmark/domain/file/presentation/FileResponseCode.java
+++ b/src/main/java/leets/bookmark/domain/file/presentation/FileResponseCode.java
@@ -6,7 +6,8 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum FileResponseCode {
-    PRE_SIGNED_URL_SUCCESS("파일 업로드 URL이 생성되었습니다.");
+    PRE_SIGNED_URL_SUCCESS("파일 업로드 URL이 생성되었습니다."),
+    S3_UPLOAD_SUCCESS("S3 업로드에 성공했습니다.");
 
     private final String message;
 }

--- a/src/main/java/leets/bookmark/global/config/AmazonS3Config.java
+++ b/src/main/java/leets/bookmark/global/config/AmazonS3Config.java
@@ -8,6 +8,7 @@ import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 @Configuration
@@ -30,6 +31,17 @@ public class AmazonS3Config {
         );
 
         return S3Presigner.builder()
+                .region(Region.of(region))
+                .credentialsProvider(credentialsProvider)
+                .build();
+    }
+
+    @Bean
+    public S3Client s3Client() {
+        AwsCredentialsProvider credentialsProvider = StaticCredentialsProvider.create(
+                AwsBasicCredentials.create(accessKey, secretKey)
+        );
+        return S3Client.builder()
                 .region(Region.of(region))
                 .credentialsProvider(credentialsProvider)
                 .build();


### PR DESCRIPTION
## ✨ 관련 이슈

- Resolved: #84

## 🔎 작업 내용

- 프론트에서 추출한 이미지가 CORS 미허용 시 pre-signed URL로 업로드 불가 문제로, 북마크 저장/수정 시 서버에서 직접 이미지 저장 

<br>


<br>

## 📷 이미지 첨부
- url 중간에 확장자가 있는 경우 (인스타)
<img width="1041" height="479" alt="image" src="https://github.com/user-attachments/assets/4458e6eb-b2bd-4c51-b57f-f59b91ade35c" />
- cors 문제로 업로드가 되지 않던 url
<img width="827" height="422" alt="image" src="https://github.com/user-attachments/assets/29dc07cd-5c77-4cd9-8ede-95947717d3c6" />




<br/>

---

## ✅ Check List
- [x] 라벨 지정
- [x] 리뷰어 지정
- [x] 담당자 지정
- [x] 테스트 완료
- [x] 이슈 제목 컨벤션 준수
- [x] PR 제목 및 설명 작성
- [x] 커밋 메시지 컨벤션 준수
