### PR TITLE
fix #91 파일 저장 버그 수정

### DIFF
--- a/src/main/java/leets/bookmark/domain/file/application/usecase/FileUseCase.java
+++ b/src/main/java/leets/bookmark/domain/file/application/usecase/FileUseCase.java
@@ -57,7 +57,7 @@ public class FileUseCase {
         String fileName = extractFileNameWithExtension(thumbnailUrl);
         FileType type = getValidatedFileType(fileName);
 
-        String s3UrlResponse = s3UploadService.upload(thumbnailUrl);
+        String s3UrlResponse = s3UploadService.upload(thumbnailUrl, type);
 
         File file = fileMapper.toThumbnailFile(user, bookmark, fileName, s3UrlResponse, type);
         fileSaveService.save(file);
@@ -86,7 +86,7 @@ public class FileUseCase {
         String fileName = extractFileNameWithExtension(thumbnailUrl);
         FileType type = getValidatedFileType(fileName);
 
-        String s3UrlResponse = s3UploadService.upload(thumbnailUrl);
+        String s3UrlResponse = s3UploadService.upload(thumbnailUrl, type);
 
         fileUpdateService.updateThumbnailImage(file, fileName, s3UrlResponse, type);
     }

--- a/src/main/java/leets/bookmark/domain/file/domain/service/S3UploadService.java
+++ b/src/main/java/leets/bookmark/domain/file/domain/service/S3UploadService.java
@@ -1,6 +1,7 @@
 package leets.bookmark.domain.file.domain.service;
 
 import leets.bookmark.domain.file.application.exception.S3UploadException;
+import leets.bookmark.domain.file.domain.entity.enums.FileType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -28,7 +29,7 @@ public class S3UploadService {
 
     private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyyMMddHHmmss");
 
-    public String upload(String fileUrl) {
+    public String upload(String fileUrl, FileType fileType) {
         try {
             URL url = URI.create(fileUrl).toURL();
             HttpURLConnection connection = (HttpURLConnection) url.openConnection();
@@ -36,7 +37,7 @@ public class S3UploadService {
 
             try (InputStream inputStream = connection.getInputStream()) {
 
-                String fileName = generateUrl(fileUrl);
+                String fileName = generateUrl(fileType);
 
                 PutObjectRequest putObjectRequest = PutObjectRequest.builder()
                         .bucket(bucket)
@@ -54,8 +55,8 @@ public class S3UploadService {
         }
     }
 
-    private String generateUrl(String fileName) {
-        String extension = fileName.substring(fileName.lastIndexOf(".") + 1);
-        return LocalDateTime.now().format(FORMATTER) + UUID.randomUUID().toString() + "." + extension;
+    private String generateUrl(FileType fileType) {
+        String extension = fileType.getExtension();
+        return LocalDateTime.now().format(FORMATTER) + UUID.randomUUID().toString() + extension;
     }
 }


### PR DESCRIPTION
## ✨ 관련 이슈

- Resolved: #91 

## 🔎 작업 내용

- S3 저장 시 파일명에 기존에 추출한 확장자를 사용하도록 수정
  - 이미 추출된 확장자가 존재하므로 중복 추출 과정은 불필요
  - URL 쿼리 파라미터가 포함된 경우 잘못된 확장자가 추출되어 오류 발생

<br>


## 📷 이미지 첨부
- 기존에 잘못된 확장자가 추출된 경우

<img width="774" height="425" alt="image" src="https://github.com/user-attachments/assets/39d991e8-689a-446d-b969-d0b1f16c35f7" />

- DB에 .jpg로 저장된 모습
<img width="223" height="32" alt="image" src="https://github.com/user-attachments/assets/3f9b81eb-81e0-4723-a4af-803dacc9dada" />


<br/>

---

## ✅ Check List
- [x] 라벨 지정
- [x] 리뷰어 지정
- [x] 담당자 지정
- [x] 테스트 완료
- [x] 이슈 제목 컨벤션 준수
- [x] PR 제목 및 설명 작성
- [x] 커밋 메시지 컨벤션 준수
