### PR TITLE
fix #90 카카오톡 알림 버그 수정

### DIFF
--- a/src/main/java/leets/bookmark/domain/notification/domain/service/KakaoNotificationService.java
+++ b/src/main/java/leets/bookmark/domain/notification/domain/service/KakaoNotificationService.java
@@ -13,6 +13,7 @@ import org.springframework.web.client.RestClient;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Optional;
 
 @RequiredArgsConstructor
 @Service
@@ -40,6 +41,7 @@ public class KakaoNotificationService {
 
         for (int i = 0; i < notificationItemRequests.size(); i++) {
             NotificationItemRequest item = notificationItemRequests.get(i);
+            String description = Optional.ofNullable(item.description()).orElse(" ");
             contentsJson.append("""
                 {
                     "title": "%s",
@@ -54,7 +56,7 @@ public class KakaoNotificationService {
                 }
             """.formatted(
                     escapeJson(item.title()),
-                    escapeJson(item.description()),
+                    description,
                     escapeJson(item.imageUrl()),
                     linkedUrl,
                     linkedUrl
@@ -89,6 +91,8 @@ public class KakaoNotificationService {
         """.formatted(notificationTitle, linkedUrl, linkedUrl, contentsJson.toString(), linkedUrl, linkedUrl);
 
         String formBody = "template_object=" + URLEncoder.encode(templateJson, StandardCharsets.UTF_8);
+
+        System.out.println(formBody);
 
         String response = kakaoRestClient.post()
                 .uri(messageSendUri)

--- a/src/main/java/leets/bookmark/domain/notification/domain/service/KakaoNotificationService.java
+++ b/src/main/java/leets/bookmark/domain/notification/domain/service/KakaoNotificationService.java
@@ -28,6 +28,9 @@ public class KakaoNotificationService {
     @Value("${kakao.message-send-uri}")
     private String messageSendUri;
 
+    @Value("${kakao.basic-image-url}")
+    private String basicImageUrl;
+
     private final RestClient kakaoRestClient;
     private final AesEncryptor aesEncryptor;
 
@@ -41,7 +44,9 @@ public class KakaoNotificationService {
 
         for (int i = 0; i < notificationItemRequests.size(); i++) {
             NotificationItemRequest item = notificationItemRequests.get(i);
+            String title = Optional.ofNullable(item.title()).orElse("제목 없음");
             String description = Optional.ofNullable(item.description()).orElse(" ");
+            String imageUrl = Optional.ofNullable(item.imageUrl()).orElse(basicImageUrl);
             contentsJson.append("""
                 {
                     "title": "%s",
@@ -55,9 +60,9 @@ public class KakaoNotificationService {
                     }
                 }
             """.formatted(
-                    escapeJson(item.title()),
-                    description,
-                    escapeJson(item.imageUrl()),
+                    escapeJson(title),
+                    escapeJson(description),
+                    escapeJson(imageUrl),
                     linkedUrl,
                     linkedUrl
             ));
@@ -91,8 +96,6 @@ public class KakaoNotificationService {
         """.formatted(notificationTitle, linkedUrl, linkedUrl, contentsJson.toString(), linkedUrl, linkedUrl);
 
         String formBody = "template_object=" + URLEncoder.encode(templateJson, StandardCharsets.UTF_8);
-
-        System.out.println(formBody);
 
         String response = kakaoRestClient.post()
                 .uri(messageSendUri)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,6 +30,7 @@ kakao:
   linked-url: ${KAKAO_LINKED_URL}
   message-send-uri: /v2/api/talk/memo/default/send
   notification-title : ${KAKAO_NOTIFICATION_TITLE}
+  basic-image-url : ${KAKAO_BASIC_IMAGE_URL}
 
 springdoc:
   swagger-ui:


### PR DESCRIPTION
## ✨ 관련 이슈

- Resolved: #90 

## 🔎 작업 내용
```
ERROR 18220 --- [   scheduling-1] l.b.d.n.d.service.NotificationScheduler  : 400 Bad Request: "{"msg":"failed to parse parameter. name=template_object, stringToParse=-, paramString=-, paramStringAlias=null","code":-2}"
```
- 해당 오류로 인해 알림이 안가지는 오류가 발생
  - 원인 : 해당 문제는 제목(title), 메모(description), 이미지 URL(imageUrl) 중 하나 이상이 ```null```일 경우 발생
  - 변경사항 : title, description, imageUrl에 대해 ```null``` 값일 경우의 처리 추가

<br>


<br>


---

## ✅ Check List
- [x] 라벨 지정
- [x] 리뷰어 지정
- [x] 담당자 지정
- [x] 테스트 완료
- [x] 이슈 제목 컨벤션 준수
- [x] PR 제목 및 설명 작성
- [x] 커밋 메시지 컨벤션 준수
