### PR TITLE
Hotfix #94 카카오 리다이렉션 설정 수정

### DIFF
--- a/src/main/java/leets/bookmark/global/auth/oauth2/application/usecase/OAuth2UseCase.java
+++ b/src/main/java/leets/bookmark/global/auth/oauth2/application/usecase/OAuth2UseCase.java
@@ -4,5 +4,5 @@ import leets.bookmark.domain.user.application.dto.response.UserKakaoLoginRespons
 
 public interface OAuth2UseCase {
 
-    UserKakaoLoginResponse kakaoLogin(String code);
+    UserKakaoLoginResponse kakaoLogin(String code, String redirectUri);
 }

--- a/src/main/java/leets/bookmark/global/auth/oauth2/application/usecase/OAuth2UseCaseImpl.java
+++ b/src/main/java/leets/bookmark/global/auth/oauth2/application/usecase/OAuth2UseCaseImpl.java
@@ -26,8 +26,8 @@ public class OAuth2UseCaseImpl implements OAuth2UseCase {
 
     @Transactional
     @Override
-    public UserKakaoLoginResponse kakaoLogin(String code) {
-        KakaoTokenResponse kakaoToken = kakaoGetService.getTokenFromKakao(code);
+    public UserKakaoLoginResponse kakaoLogin(String code, String redirectUri) {
+        KakaoTokenResponse kakaoToken = kakaoGetService.getTokenFromKakao(code, redirectUri);
         KakaoUserInfoResponse kakaoUserInfo = kakaoGetService.getUserInfo(kakaoToken.accessToken());
 
         User user = userSaveService.save(kakaoUserInfo);

--- a/src/main/java/leets/bookmark/global/auth/oauth2/service/KakaoGetService.java
+++ b/src/main/java/leets/bookmark/global/auth/oauth2/service/KakaoGetService.java
@@ -6,7 +6,6 @@ import leets.bookmark.global.auth.oauth2.application.exception.KakaoAccessTokenI
 import leets.bookmark.global.auth.oauth2.application.exception.KakaoAuthorizationCodeInvalidException;
 import leets.bookmark.global.auth.oauth2.application.exception.KakaoServerException;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.stereotype.Service;
@@ -15,15 +14,12 @@ import reactor.core.publisher.Mono;
 
 import static org.springframework.http.HttpHeaders.*;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 public class KakaoGetService {
 
     @Value("${spring.security.oauth2.client.registration.kakao.client-id}")
     private String clientId;
-    @Value("${spring.security.oauth2.client.registration.kakao.redirect-uri}")
-    private String redirectUri;
     @Value("${spring.security.oauth2.client.provider.kakao.token-uri}")
     private String tokenUri;
     @Value("${spring.security.oauth2.client.provider.kakao.user-info-uri}")
@@ -32,7 +28,7 @@ public class KakaoGetService {
     public static final String BEARER = "Bearer ";
     public static final String APPLICATION_X_WWW_FORM_URLENCODED_CHARSET_UTF_8 = "application/x-www-form-urlencoded;charset=utf-8";
 
-    public KakaoTokenResponse getTokenFromKakao(String code) {
+    public KakaoTokenResponse getTokenFromKakao(String code, String redirectUri) {
         return WebClient.create(tokenUri).post()
                 .uri(uriBuilder -> uriBuilder
                         .queryParam("grant_type", "authorization_code")

--- a/src/main/java/leets/bookmark/global/auth/presentation/AuthController.java
+++ b/src/main/java/leets/bookmark/global/auth/presentation/AuthController.java
@@ -29,8 +29,8 @@ public class AuthController {
     }
 
     @GetMapping("/login/kakao")
-    public CommonResponse<UserKakaoLoginResponse> kakaoLogin(@RequestParam("code") String code) {
-        UserKakaoLoginResponse response = oAuth2UseCase.kakaoLogin(code);
+    public CommonResponse<UserKakaoLoginResponse> kakaoLogin(@RequestParam("code") String code, @RequestParam("redirectUri") String redirectUri) {
+        UserKakaoLoginResponse response = oAuth2UseCase.kakaoLogin(code, redirectUri);
         return CommonResponse.createSuccess(KAKAO_LOGIN_SUCCESS.getMessage(), response);
     }
 }


### PR DESCRIPTION
## ✨ 관련 이슈

- Resolved: #94

## 🔎 작업 내용

- 배포된 서버와 로컬 환경의 리다이렉션을 위해 카카오 인증 API에서 Redirect URI를 파라미터로 받음으로써 카카오 리다이렉트 URI 설정을 동적으로 변경했습니다.

<br>

## 📌 참고 사항
- 기타 안내사항
  - `/api/v1/auth/login/kakao` API에서 필수 파라미터를 code뿐만 아니라 redirectUri도 함께 넘겨주어야 합니다.

<br>

## 📷 이미지 첨부
- Redirect URI를 3000번과 8000번 포트로 다르게 테스트 한 결과 잘 받아지고 있는 것을 확인했습니다.
다른 Redirect URI로 요청할 경우 카카오 서버에서 자동으로 요청을 거부합니다.
<br>
<img width="1334" height="25" alt="스크린샷 2025-08-06 오전 11 19 21" src="https://github.com/user-attachments/assets/10ca57b8-c704-4dcf-a711-1b35b509c6a5" />
<img width="1334" height="25" alt="스크린샷 2025-08-06 오전 11 19 43" src="https://github.com/user-attachments/assets/e207a7a3-4a2e-43e6-88b2-762502aa4e90" />

<br/>

---

## ✅ Check List
- [x] 라벨 지정
- [x] 리뷰어 지정
- [x] 담당자 지정
- [x] 테스트 완료
- [x] 이슈 제목 컨벤션 준수
- [x] PR 제목 및 설명 작성
- [x] 커밋 메시지 컨벤션 준수
