### PR TITLE
Feat #96 이미지 url을 통한 파일 반환 기능 추가

### DIFF
--- a/src/main/java/leets/bookmark/domain/file/application/dto/response/FetchedThumbnailResponse.java
+++ b/src/main/java/leets/bookmark/domain/file/application/dto/response/FetchedThumbnailResponse.java
@@ -1,0 +1,11 @@
+package leets.bookmark.domain.file.application.dto.response;
+
+import lombok.Builder;
+import org.springframework.core.io.InputStreamResource;
+import org.springframework.http.MediaType;
+
+@Builder
+public record FetchedThumbnailResponse(
+        InputStreamResource inputStreamResource,
+        MediaType mediaType
+) {}

--- a/src/main/java/leets/bookmark/domain/file/application/exception/FileErrorCode.java
+++ b/src/main/java/leets/bookmark/domain/file/application/exception/FileErrorCode.java
@@ -11,7 +11,8 @@ public enum FileErrorCode implements ErrorCode {
     FILE_NOT_FOUND_EXCEPTION(404,"해당하는 파일을 찾을 수 없습니다."),
     INVALID_FILE_EXTENSION(400, "올바르지 않은 파일 확장자입니다."),
     FILE_OWNER_MISMATCH_EXCEPTION(403, "파일 소유자만 접근 가능합니다."),
-    S3_UPLOAD_EXCEPTION(500, "파일 업로드에 실패하였습니다.");
+    S3_UPLOAD_EXCEPTION(500, "파일 업로드에 실패하였습니다."),
+    IMAGE_FETCH_EXCEPTION(500, "이미지를 가져올 수 없습니다.");
 
     private final int errorCode;
     private final String message;

--- a/src/main/java/leets/bookmark/domain/file/application/exception/ImageFetchException.java
+++ b/src/main/java/leets/bookmark/domain/file/application/exception/ImageFetchException.java
@@ -1,0 +1,9 @@
+package leets.bookmark.domain.file.application.exception;
+
+import leets.bookmark.global.common.exception.BusinessException;
+
+public class ImageFetchException extends BusinessException {
+    public ImageFetchException(){
+        super(FileErrorCode.IMAGE_FETCH_EXCEPTION);
+    }
+}

--- a/src/main/java/leets/bookmark/domain/file/application/mapper/FileMapper.java
+++ b/src/main/java/leets/bookmark/domain/file/application/mapper/FileMapper.java
@@ -2,10 +2,13 @@ package leets.bookmark.domain.file.application.mapper;
 
 import leets.bookmark.domain.bookmark.domain.entity.Bookmark;
 import leets.bookmark.domain.file.application.dto.request.FileSaveRequest;
+import leets.bookmark.domain.file.application.dto.response.FetchedThumbnailResponse;
 import leets.bookmark.domain.file.application.dto.response.FileResponse;
 import leets.bookmark.domain.file.domain.entity.File;
 import leets.bookmark.domain.file.domain.entity.enums.FileType;
 import leets.bookmark.domain.user.domain.entity.User;
+import org.springframework.core.io.InputStreamResource;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -39,6 +42,14 @@ public class FileMapper {
                 .fileName(file.getFileName())
                 .createdAt(file.getCreatedAt())
                 .updatedAt(file.getUpdatedAt())
+                .build();
+    }
+
+    public FetchedThumbnailResponse toFetchedThumbnailResponse(InputStreamResource inputStreamResource,
+                                                               MediaType mediaType){
+        return FetchedThumbnailResponse.builder()
+                .inputStreamResource(inputStreamResource)
+                .mediaType(mediaType)
                 .build();
     }
 }

--- a/src/main/java/leets/bookmark/domain/file/application/usecase/FileUseCase.java
+++ b/src/main/java/leets/bookmark/domain/file/application/usecase/FileUseCase.java
@@ -116,7 +116,9 @@ public class FileUseCase {
             String fileName = extractFileNameWithExtension(thumbnailUrl);
             FileType fileType = getValidatedFileType(thumbnailUrl);
 
-            URL url = URI.create(thumbnailUrl).toURL();
+            URI uri = URI.create(thumbnailUrl);
+
+            URL url = new URL(uri.toASCIIString());
 
             HttpURLConnection connection = (HttpURLConnection) url.openConnection();
             connection.setRequestMethod("GET");

--- a/src/main/java/leets/bookmark/domain/file/application/usecase/FileUseCase.java
+++ b/src/main/java/leets/bookmark/domain/file/application/usecase/FileUseCase.java
@@ -4,9 +4,11 @@ import jakarta.validation.Valid;
 import leets.bookmark.domain.bookmark.domain.entity.Bookmark;
 import leets.bookmark.domain.file.application.dto.request.FileSaveRequest;
 import leets.bookmark.domain.file.application.dto.request.FileUpdateRequest;
+import leets.bookmark.domain.file.application.dto.response.FetchedThumbnailResponse;
 import leets.bookmark.domain.file.application.dto.response.FileResponse;
 import leets.bookmark.domain.file.application.dto.response.PresignedUrlResponse;
 import leets.bookmark.domain.file.application.exception.FileOwnerMismatchException;
+import leets.bookmark.domain.file.application.exception.ImageFetchException;
 import leets.bookmark.domain.file.application.exception.InvalidFileExtensionException;
 import leets.bookmark.domain.file.application.mapper.FileMapper;
 import leets.bookmark.domain.file.application.mapper.PreSignedMapper;
@@ -16,10 +18,20 @@ import leets.bookmark.domain.file.domain.service.*;
 import leets.bookmark.domain.user.domain.entity.User;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.io.InputStreamResource;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;
 
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URL;
+import java.util.Optional;
+
+@Slf4j
 @Validated
 @Service
 @RequiredArgsConstructor
@@ -97,6 +109,30 @@ public class FileUseCase {
         validateFileOwner(user, file);
 
         fileDeleteService.delete(file);
+    }
+
+    public FetchedThumbnailResponse getThumbnailImage(String thumbnailUrl) {
+        try {
+            String fileName = extractFileNameWithExtension(thumbnailUrl);
+            FileType fileType = getValidatedFileType(thumbnailUrl);
+
+            URL url = URI.create(thumbnailUrl).toURL();
+
+            HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+            connection.setRequestMethod("GET");
+
+            InputStream inputStream = connection.getInputStream();
+
+            String contentType = Optional.ofNullable(connection.getContentType())
+                    .orElse("application/octet-stream");
+            MediaType mediaType = MediaType.parseMediaType(contentType);
+
+            return fileMapper.toFetchedThumbnailResponse(new InputStreamResource(inputStream), mediaType);
+
+        } catch (Exception e){
+            log.warn("썸네일 이미지를 가져오는 중 오류 발생. URL: {}", thumbnailUrl, e);
+            throw new ImageFetchException();
+        }
     }
 
     private void validateFileOwner(User user, File file){

--- a/src/main/java/leets/bookmark/domain/file/application/usecase/FileUseCase.java
+++ b/src/main/java/leets/bookmark/domain/file/application/usecase/FileUseCase.java
@@ -105,15 +105,8 @@ public class FileUseCase {
         }
     }
 
-    private String getExtension(String fileName){
-        if(fileName == null || !fileName.contains(".")){
-            throw new InvalidFileExtensionException();
-        }
-        return fileName.substring(fileName.lastIndexOf(".")).toLowerCase();
-    }
-
     private FileType getValidatedFileType(String fileName){
-       return FileType.fromExtension(getExtension(getExtension(fileName)))
+       return FileType.fromFileName(fileName)
                 .orElseThrow(InvalidFileExtensionException::new);
     }
 

--- a/src/main/java/leets/bookmark/domain/file/domain/entity/enums/FileType.java
+++ b/src/main/java/leets/bookmark/domain/file/domain/entity/enums/FileType.java
@@ -24,15 +24,6 @@ public enum FileType {
 
     private final String extension;
 
-    public static Optional<FileType> fromExtension(String ext){
-        if(ext == null){
-            return Optional.empty();
-        }
-        return Stream.of(FileType.values())
-                .filter(fileType -> fileType.getExtension().equalsIgnoreCase(ext))
-                .findFirst();
-    }
-
     public static Optional<FileType> fromFileName(String fileName) {
         return Stream.of(FileType.values())
                 .filter(fileType -> fileName.toLowerCase().contains(fileType.getExtension()))

--- a/src/main/java/leets/bookmark/domain/file/presentation/FileController.java
+++ b/src/main/java/leets/bookmark/domain/file/presentation/FileController.java
@@ -1,10 +1,13 @@
 package leets.bookmark.domain.file.presentation;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
+import leets.bookmark.domain.file.application.dto.response.FetchedThumbnailResponse;
 import leets.bookmark.domain.file.application.dto.response.PresignedUrlResponse;
 import leets.bookmark.domain.file.application.usecase.FileUseCase;
 import leets.bookmark.global.common.response.CommonResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.core.io.Resource;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "FILE", description = "파일 API")
@@ -19,6 +22,14 @@ public class FileController {
     public CommonResponse<PresignedUrlResponse> getPresignedUrl(@RequestParam String fileName) {
         PresignedUrlResponse response = fileUseCase.getPreSignedUrl(fileName);
         return CommonResponse.createSuccess(FileResponseCode.PRE_SIGNED_URL_SUCCESS.getMessage(), response);
+    }
+
+    @GetMapping("/thumbnail-image")
+    public ResponseEntity<Resource> getThumbnailImage(@RequestParam String thumbnailUrl) {
+        FetchedThumbnailResponse response = fileUseCase.getThumbnailImage(thumbnailUrl);
+        return ResponseEntity.ok()
+                .contentType(response.mediaType())
+                .body(response.inputStreamResource());
     }
 
 }


### PR DESCRIPTION
## ✨ 관련 이슈

- Resolved: #96 

## 🔎 작업 내용

- 현재 CORS 정책으로 인해 특정 도메인에서 이미지를 프론트엔드에서 바로 표시할 수 없는 문제가 발생하고 있습니다. 
- 이로 인해 사용자가 외부 URL에서 이미지를 직접 로드가 불가하여, 썸네일용 이미지를 서버 측에서 반환하는 기능을 추가하였습니다

<br>


## 📌 참고 사항

- 주의해야 할 점 <!--(선택 사항)-->
  - 외부 URL의 파라미터가 인코딩되지 않아 서버에서 정상적으로 처리되지 않는 이슈가 발생할 수 있습니다.
  - 프론트엔드에서 URL 인코딩을 적용한 후 요청 해야 합니다
  - (수정) 해당 부분 서버에서 ASCII 포맷을 적용해서 해결하였습니다



<!-- 내용이 없을 경우 해당 항목은 삭제해 주세요 -->

<br>

## 📷 이미지 첨부
- 네이버의 CORS 차단으로 인해 프론트엔드에서 표시되지 않던 이미지
<br>
<img width="1008" height="662" alt="image" src="https://github.com/user-attachments/assets/74fb1705-2004-4932-8f35-8cd53c8157a1" />

<br/>

---

## ✅ Check List
- [x] 라벨 지정
- [x] 리뷰어 지정
- [x] 담당자 지정
- [x] 테스트 완료
- [x] 이슈 제목 컨벤션 준수
- [x] PR 제목 및 설명 작성
- [x] 커밋 메시지 컨벤션 준수
