### PR TITLE
Hotfix #100 카카오 로그인 시 간헐적으로 다른 사용자로 로그인되는 현상 수정

### DIFF
--- a/src/main/java/leets/bookmark/global/auth/oauth2/application/usecase/OAuth2UseCaseImpl.java
+++ b/src/main/java/leets/bookmark/global/auth/oauth2/application/usecase/OAuth2UseCaseImpl.java
@@ -41,8 +41,6 @@ public class OAuth2UseCaseImpl implements OAuth2UseCase {
         JwtTokenDto jwtToken = jwtProvider.createToken(user);
         user.updateJwtTokens(jwtToken.accessToken(), jwtToken.refreshToken());
 
-        userSaveService.save(user);
-
         return userMapper.toUserKakaoLoginResponse(user);
     }
 }


### PR DESCRIPTION
## ✨ 관련 이슈

- Resolved: #100 

## 🔎 작업 내용

- 카카오 소셜 로그인 시, 간헐적으로 본인이 아닌 다른 사용자의 정보로 로그인되는 현상이 발생
  - kakaoLogin() 메서드 내에서 이미 영속 상태로 조회된 User 객체에 대해 ```userSaveService.save(user)```를 다시 호출하면서, 내부적으로 JPA의 merge()가 발생
  - 이로인해 병합 시점에 사용자 정보가 잘못되어 다른 사람으로 덮어지는 것으로 유추됩니다


<br>



---

## ✅ Check List
- [x] 라벨 지정
- [x] 리뷰어 지정
- [x] 담당자 지정
- [x] 테스트 완료
- [x] 이슈 제목 컨벤션 준수
- [x] PR 제목 및 설명 작성
- [x] 커밋 메시지 컨벤션 준수
