### PR TITLE
fix #102 알림이 1개일 경우 list 템플릿 대신 feed 템플릿 사용

### DIFF
--- a/src/main/java/leets/bookmark/domain/notification/domain/service/KakaoNotificationService.java
+++ b/src/main/java/leets/bookmark/domain/notification/domain/service/KakaoNotificationService.java
@@ -1,5 +1,7 @@
 package leets.bookmark.domain.notification.domain.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import leets.bookmark.global.auth.oauth2.application.dto.request.NotificationItemRequest;
 import leets.bookmark.domain.user.domain.entity.User;
 import leets.bookmark.global.auth.oauth2.service.KakaoTokenRefreshService;
@@ -12,8 +14,7 @@ import org.springframework.web.client.RestClient;
 
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 
 @RequiredArgsConstructor
 @Service
@@ -36,64 +37,72 @@ public class KakaoNotificationService {
 
     private final KakaoTokenRefreshService kakaoTokenRefreshService;
 
-    public void sendListTemplate(User user, List<NotificationItemRequest> notificationItemRequests) {
+    public void sendListTemplate(User user, List<NotificationItemRequest> notificationItemRequests) throws JsonProcessingException {
 
-        kakaoTokenRefreshService.refreshAccessToken(user);  // 토큰 갱신
-        
-        StringBuilder contentsJson = new StringBuilder("[");
+        kakaoTokenRefreshService.refreshAccessToken(user);
 
-        for (int i = 0; i < notificationItemRequests.size(); i++) {
-            NotificationItemRequest item = notificationItemRequests.get(i);
-            String title = Optional.ofNullable(item.title()).orElse("제목 없음");
-            String description = Optional.ofNullable(item.description()).orElse(" ");
-            String imageUrl = Optional.ofNullable(item.imageUrl()).orElse(basicImageUrl);
-            contentsJson.append("""
-                {
-                    "title": "%s",
-                    "description": "%s",
-                    "image_url": "%s",
-                    "image_width": 640,
-                    "image_height": 640,
-                    "link": {
-                        "web_url": "%s",
-                        "mobile_web_url": "%s"
-                    }
-                }
-            """.formatted(
-                    escapeJson(title),
-                    escapeJson(description),
-                    escapeJson(imageUrl),
-                    linkedUrl,
-                    linkedUrl
+        ObjectMapper objectMapper = new ObjectMapper();
+        Map<String, Object> templateMap = new HashMap<>();
+
+        // 알림이 1개일 경우
+        if (notificationItemRequests.size() == 1) {
+            NotificationItemRequest item = notificationItemRequests.get(0);
+
+            templateMap.put("object_type", "feed");
+            templateMap.put("content", Map.of(
+                    "title", Optional.ofNullable(item.title()).orElse("제목 없음"),
+                    "description", Optional.ofNullable(item.description()).orElse(" "),
+                    "image_url", Optional.ofNullable(item.imageUrl()).orElse(basicImageUrl),
+                    "image_width", 640,
+                    "image_height", 640,
+                    "link", Map.of(
+                            "web_url", linkedUrl,
+                            "mobile_web_url", linkedUrl
+                    )
             ));
 
-            if (i < notificationItemRequests.size() - 1) {
-                contentsJson.append(",");
+            templateMap.put("buttons", List.of(Map.of(
+                    "title", "웹으로 이동",
+                    "link", Map.of(
+                            "web_url", linkedUrl,
+                            "mobile_web_url", linkedUrl
+                    )
+            )));
+
+        } else if (notificationItemRequests.size() >= 2) {
+            templateMap.put("object_type", "list");
+            templateMap.put("header_title", notificationTitle);
+            templateMap.put("header_link", Map.of(
+                    "web_url", linkedUrl,
+                    "mobile_web_url", linkedUrl
+            ));
+
+            List<Map<String, Object>> contents = new ArrayList<>();
+            for (NotificationItemRequest item : notificationItemRequests) {
+                contents.add(Map.of(
+                        "title", Optional.ofNullable(item.title()).orElse("제목 없음"),
+                        "description", Optional.ofNullable(item.description()).orElse(" "),
+                        "image_url", Optional.ofNullable(item.imageUrl()).orElse(basicImageUrl),
+                        "image_width", 640,
+                        "image_height", 640,
+                        "link", Map.of(
+                                "web_url", linkedUrl,
+                                "mobile_web_url", linkedUrl
+                        )
+                ));
             }
+
+            templateMap.put("contents", contents);
+            templateMap.put("buttons", List.of(Map.of(
+                    "title", "웹으로 이동",
+                    "link", Map.of(
+                            "web_url", linkedUrl,
+                            "mobile_web_url", linkedUrl
+                    )
+            )));
         }
 
-        contentsJson.append("]");
-
-        String templateJson = """
-            {
-                "object_type": "list",
-                "header_title": "%s",
-                "header_link": {
-                    "web_url": "%s",
-                    "mobile_web_url": "%s"
-                },
-                "contents": %s,
-                "buttons": [
-                    {
-                        "title": "웹으로 이동",
-                        "link": {
-                            "web_url": "%s",
-                            "mobile_web_url": "%s"
-                        }
-                    }
-                ]
-            }
-        """.formatted(notificationTitle, linkedUrl, linkedUrl, contentsJson.toString(), linkedUrl, linkedUrl);
+        String templateJson = objectMapper.writeValueAsString(templateMap);
 
         String formBody = "template_object=" + URLEncoder.encode(templateJson, StandardCharsets.UTF_8);
 
@@ -108,8 +117,4 @@ public class KakaoNotificationService {
                 .body(String.class);
     }
 
-    private String escapeJson(String str) {
-        if (str == null) return "";
-        return str.replace("\"", "\\\"");
-    }
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -9,7 +9,6 @@ spring:
     password: ${DB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
-    show-sql: true
     hibernate:
       ddl-auto: update
     properties:


### PR DESCRIPTION
## ✨ 관련 이슈

- Resolved: #102 

## 🔎 작업 내용

- 기존에는 알림의 개수와 상관 없이 list 템플릿을 사용했기 때문에 Kakao API의 최소 콘텐츠 수 조건(2개 이상)을 만족하지 못할 경우 400 Bad Request가 발생
  - 알림이 1개일 경우 feed 템플릿을 사용
- dev 환경에서 알림 및 다른 오류를 집중적으로 보기 위해 SQL 로그를 비활성화 하였습니다
<br>

<br>

## 📷 이미지 첨부
- 알림 1개와 알림 3개일 경우의 각 템플릿
<br>
<img width="221" height="690" alt="image" src="https://github.com/user-attachments/assets/f5cdf02e-e580-4a12-8d47-8fb10a169869" />
<br/>
- 알림 메모에 "가 포함된 경우 (JSON 형식 오류 테스트)
<br>
<img width="216" height="347" alt="image" src="https://github.com/user-attachments/assets/0a39dd33-8dcc-433e-8d9f-1068a2b92230" />


---

## ✅ Check List
- [x] 라벨 지정
- [x] 리뷰어 지정
- [x] 담당자 지정
- [x] 테스트 완료
- [x] 이슈 제목 컨벤션 준수
- [x] PR 제목 및 설명 작성
- [x] 커밋 메시지 컨벤션 준수
